### PR TITLE
reduce to unique paths

### DIFF
--- a/R/select_tables_from_dm.R
+++ b/R/select_tables_from_dm.R
@@ -72,10 +72,10 @@ cdm_find_conn_tbls <- function(dm, ...) {
     abort_vertices_not_connected()
   }
 
-  V_ids <- map_int(table_names, ~ which(V == .x))
-  all_comb <- crossing(table_names, V_ids)
-  ids_vec <- pull(all_comb, V_ids)
-  names_vec <- pull(all_comb, table_names)
+  all_comb <- crossing(from = table_names, to = table_names) %>%
+    filter(from < to)
+  ids_vec <- pull(all_comb, from) %>% map(~(V == .)) %>% map_int(which)
+  names_vec <- pull(all_comb, to)
 
   result_table_names_unordered <-
     map2(

--- a/R/select_tables_from_dm.R
+++ b/R/select_tables_from_dm.R
@@ -74,7 +74,7 @@ cdm_find_conn_tbls <- function(dm, ...) {
 
   all_comb <- crossing(from = table_names, to = table_names) %>%
     filter(from < to)
-  ids_vec <- pull(all_comb, from) %>% map(~(V == .)) %>% map_int(which)
+  ids_vec <- pull(all_comb, from) %>% map_int(~which(V == .))
   names_vec <- pull(all_comb, to)
 
   result_table_names_unordered <-


### PR DESCRIPTION
until we find a better solution we can just as well optimize the suboptimal solution that we have(?)

``` r
library(tidyverse)

m <- c("one", "two", "three")

crossing(m, m)
#> # A tibble: 9 x 2
#>   m     m1   
#>   <chr> <chr>
#> 1 one   one  
#> 2 one   three
#> 3 one   two  
#> 4 three one  
#> 5 three three
#> 6 three two  
#> 7 two   one  
#> 8 two   three
#> 9 two   two

crossing(from = m, to = m) %>% 
  filter(from < to)
#> # A tibble: 3 x 2
#>   from  to   
#>   <chr> <chr>
#> 1 one   three
#> 2 one   two  
#> 3 three two
```

<sup>Created on 2019-07-25 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>