### PR TITLE
explain rejected candidates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,6 +51,7 @@ Suggests:
     testthat (>= 2.1.0),
     knitr,
     rmarkdown,
+    RPostgres,
     RSQLite,
     tidyverse,
     vctrs

--- a/R/db-helpers.R
+++ b/R/db-helpers.R
@@ -169,6 +169,7 @@ is_mssql <- function(dest) {
 
 is_postgres <- function(dest) {
   inherits(dest, "src_PostgreSQLConnection") ||
+    inherits(dest, "src_PqConnection") ||
     inherits(dest, "PostgreSQLConnection") ||
     inherits(dest, "PqConnection")
 }

--- a/R/filter-helpers.R
+++ b/R/filter-helpers.R
@@ -74,5 +74,5 @@ cdm_update_table <- function(dm, name, table) {
 #' @param dm A [`dm`] object
 #' @export
 cdm_nrow <- function(dm) {
-  sum(map_dbl(cdm_get_tables(dm), ~ as_double(pull(collect(count(.))))))
+  sum(map_dbl(cdm_get_tables(dm), ~ as.numeric(pull(collect(count(.))))))
 }

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -251,6 +251,7 @@ cdm_enum_fk_candidates <- function(dm, table, ref_table) h(~ {
     ref_table_pk = ref_tbl_pk,
     table = table_name,
     column = tbl_colnames,
-    candidate = subsets
+    candidate = subsets,
+    why = if_else(subsets, "", paste0("not a subset of ", ref_table, "$", ref_table_pk))
   )
 })

--- a/R/key-helpers.R
+++ b/R/key-helpers.R
@@ -42,7 +42,7 @@ check_key <- function(.data, ...) {
 }
 
 # internal function to check if a column is a unique key of a table
-is_unique_key <- function(.data, column) {
+is_unique_key <- function(.data, column) h(~ {
   if (is_symbol(enexpr(column))) {
     col_expr <- enexpr(column)
     col_name <- as_name(col_expr)
@@ -55,14 +55,17 @@ is_unique_key <- function(.data, column) {
 
   duplicate_rows <-
     .data %>%
-    count(!!col_expr) %>%
-    select(n) %>%
+    count(value = !!col_expr) %>%
     filter(n != 1) %>%
-    head(1) %>%
-    collect()
+    arrange(value) %>%
+    head(7) %>%
+    collect() %>%
+    nest() %>%
+    mutate(column = col_name) %>%
+    mutate(unique = map_lgl(data, ~ nrow(.) == 0))
 
-  nrow(duplicate_rows) == 0
-}
+  duplicate_rows
+})
 
 
 #' Test if the value sets of two different columns in two different tables are the same

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -235,7 +235,8 @@ enum_pk_candidates <- function(table) h(~ {
   # list of ayes and noes:
   map_lgl(tbl_colnames, ~ is_unique_key(table, {{.x}})) %>%
     set_names(tbl_colnames) %>%
-    enframe(name = "column", value = "candidate")
+    enframe(name = "column", value = "candidate") %>%
+    mutate(why = if_else(candidate, "", "has duplicate values"))
 })
 
 

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -233,10 +233,12 @@ enum_pk_candidates <- function(table) h(~ {
   tbl_colnames <- colnames(table)
 
   # list of ayes and noes:
-  map_lgl(tbl_colnames, ~ is_unique_key(table, {{.x}})) %>%
-    set_names(tbl_colnames) %>%
-    enframe(name = "column", value = "candidate") %>%
-    mutate(why = if_else(candidate, "", "has duplicate values"))
+  map_dfr(tbl_colnames, ~ is_unique_key(table, {{.x}})) %>%
+    rename(candidate = unique) %>%
+    mutate(values = map_chr(data, ~ commas(format(.$value)))) %>%
+    select(-data) %>%
+    mutate(why = if_else(candidate, "", paste0("has duplicate values: ", values))) %>%
+    select(-values)
 })
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,7 +5,7 @@ commas <- function(x) {
     x <- ""
   } else if (length(x) > MAX_COMMAS) {
     length(x) <- MAX_COMMAS + 1L
-    x[[MAX_COMMAS]] <- clisymbols::symbol$ellipsis
+    x[[MAX_COMMAS]] <- cli::symbol$ellipsis
   }
 
   glue_collapse(x, sep = ", ")

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,12 @@
+MAX_COMMAS <- 5L
+
+commas <- function(x) {
+  if (is_empty(x)) {
+    x <- ""
+  } else if (length(x) > MAX_COMMAS) {
+    length(x) <- MAX_COMMAS + 1L
+    x[[MAX_COMMAS]] <- clisymbols::symbol$ellipsis
+  }
+
+  glue_collapse(x, sep = ", ")
+}

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -38,7 +38,8 @@ if (packageVersion("RSQLite") >= "2.1.1.9003") {
 
 local(try(
   {
-    src <- src_postgres(dbname = "postgres", host = "localhost", port = 5432, user = "postgres")
+    con <- DBI::dbConnect(RPostgres::Postgres(), dbname = "postgres", host = "localhost", port = 5432, user = "postgres")
+    src <- src_dbi(con, auto_disconnect = TRUE)
     test_register_src("postgres", src)
     clear_postgres()
   },

--- a/tests/testthat/test-foreign-key-functions.R
+++ b/tests/testthat/test-foreign-key-functions.R
@@ -161,11 +161,11 @@ test_that("cdm_rm_fk() works as intended?", {
 test_that("cdm_enum_fk_candidates() works as intended?", {
 
   tbl_fk_candidates_t1_t4 <- tribble(
-    ~candidate, ~column, ~table,        ~ref_table,    ~ref_table_pk,
-    TRUE,       "a",     "cdm_table_1", "cdm_table_4", "c",
-    FALSE,      "b",     "cdm_table_1", "cdm_table_4", "c"
+    ~candidate, ~column, ~table,        ~ref_table,    ~ref_table_pk, ~why,
+    TRUE,       "a",     "cdm_table_1", "cdm_table_4", "c", "",
+    FALSE,      "b",     "cdm_table_1", "cdm_table_4", "c", "not a subset of cdm_table_4$c"
   ) %>%
-    select(ref_table, ref_table_pk, table, column, candidate)
+    select(ref_table, ref_table_pk, table, column, candidate, why)
 
   map(
     .x = cdm_test_obj_src,

--- a/tests/testthat/test-primary-key-functions.R
+++ b/tests/testthat/test-primary-key-functions.R
@@ -122,8 +122,8 @@ test_that("cdm_get_pk() works as intended?", {
 })
 
 test_that("cdm_enum_pk_candidates() works properly?", {
-  candidates_table_1 <- tibble(column = c("a", "b"), candidate = c(TRUE, TRUE))
-  candidates_table_2 <- tibble(column = c("c"), candidate = c(FALSE))
+  candidates_table_1 <- tibble(column = c("a", "b"), candidate = c(TRUE, TRUE), why = c("", ""))
+  candidates_table_2 <- tibble(column = c("c"), candidate = c(FALSE), why = "has duplicate values")
 
   iwalk(
     cdm_test_obj_src,

--- a/tests/testthat/test-primary-key-functions.R
+++ b/tests/testthat/test-primary-key-functions.R
@@ -123,7 +123,7 @@ test_that("cdm_get_pk() works as intended?", {
 
 test_that("cdm_enum_pk_candidates() works properly?", {
   candidates_table_1 <- tibble(column = c("a", "b"), candidate = c(TRUE, TRUE), why = c("", ""))
-  candidates_table_2 <- tibble(column = c("c"), candidate = c(FALSE), why = "has duplicate values")
+  candidates_table_2 <- tibble(column = c("c"), candidate = c(FALSE), why = "has duplicate values: 5")
 
   iwalk(
     cdm_test_obj_src,


### PR DESCRIPTION
- `enum_pk_candidates()`, `cdm_enum_pk_candidates()` and `cdm_enum_fk_candidates()` explain now rejections in a new column `why` (admittedly rather superficially)