### PR TITLE
Simplify updating dm objects

### DIFF
--- a/R/db-helpers.R
+++ b/R/db-helpers.R
@@ -76,14 +76,12 @@ create_queries <- function(
   }
 
   if (!is_null(fk_information)) {
-    q_adapt_fk_col_classes <- queries_adapt_fk_col_classes(dest, fk_information)
     q_set_fk_relations <- queries_set_fk_relations(dest, fk_information)
   } else {
-    q_adapt_fk_col_classes <- ""
     q_set_fk_relations <- ""
   }
 
-  queries <- c(q_set_pk_cols, q_adapt_fk_col_classes, q_set_fk_relations)
+  queries <- c(q_set_pk_cols, q_set_fk_relations)
   queries[queries != ""]
 }
 
@@ -99,10 +97,6 @@ queries_set_pk_cols <- function(dest, pk_information) {
   } else {
     return("")
   }
-}
-
-queries_adapt_fk_col_classes <- function(dest, fk_information) {
-  ""
 }
 
 queries_set_fk_relations <- function(dest, fk_information) {

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -64,10 +64,10 @@ cdm_copy_to <- nse_function(c(dest, dm, ..., types = NULL, overwrite = NULL, set
 
   new_src <- src_from_src_or_con(dest)
 
-  remote_dm <- new_dm(
+  remote_dm <- new_dm2(
     src = new_src,
     tables = new_tables,
-    data_model = cdm_get_data_model(dm)
+    base_dm = dm
   )
 
   if (set_key_constraints && is_src_db(remote_dm)) {

--- a/R/dm.R
+++ b/R/dm.R
@@ -70,6 +70,8 @@ new_dm <- function(src, tables, data_model) {
 
   columns <- as_tibble(data_model$columns)
 
+  data_model_tables <- data_model$tables
+
   keys <- columns %>%
     select(column, table, key) %>%
     filter(key > 0) %>%
@@ -89,11 +91,15 @@ new_dm <- function(src, tables, data_model) {
       as_tibble()
   }
 
+  new_dm2(src, tables, data_model_tables, keys, references)
+}
+
+new_dm2 <- function(src, tables, data_model_tables, keys, references) {
   structure(
     list(
       src = src,
       tables = tables,
-      data_model_tables = data_model$tables,
+      data_model_tables = data_model_tables,
       data_model_keys = keys,
       data_model_references = references
     ),

--- a/R/dm.R
+++ b/R/dm.R
@@ -94,7 +94,13 @@ new_dm <- function(src, tables, data_model) {
   new_dm2(src, tables, data_model_tables, keys, references)
 }
 
-new_dm2 <- function(src, tables, data_model_tables, keys, references) {
+new_dm2 <- function(src = cdm_get_src(base_dm),
+                    tables = cdm_get_tables(base_dm),
+                    data_model_tables = cdm_get_data_model_tables(base_dm),
+                    keys = cdm_get_data_model_keys(base_dm),
+                    references = cdm_get_data_model_references(base_dm),
+                    base_dm) {
+
   structure(
     list(
       src = src,

--- a/R/dm.R
+++ b/R/dm.R
@@ -97,8 +97,8 @@ new_dm <- function(src, tables, data_model) {
 new_dm2 <- function(src = cdm_get_src(base_dm),
                     tables = cdm_get_tables(base_dm),
                     data_model_tables = cdm_get_data_model_tables(base_dm),
-                    keys = cdm_get_data_model_keys(base_dm),
-                    references = cdm_get_data_model_references(base_dm),
+                    pks = cdm_get_data_model_pks(base_dm),
+                    fks = cdm_get_data_model_fks(base_dm),
                     base_dm) {
 
   structure(
@@ -106,8 +106,8 @@ new_dm2 <- function(src = cdm_get_src(base_dm),
       src = src,
       tables = tables,
       data_model_tables = data_model_tables,
-      data_model_keys = keys,
-      data_model_references = references
+      data_model_pks = pks,
+      data_model_fks = fks
     ),
     class = "dm"
   )
@@ -162,12 +162,12 @@ cdm_get_data_model_tables <- function(x) {
   unclass(x)$data_model_tables
 }
 
-cdm_get_data_model_keys <- function(x) {
-  unclass(x)$data_model_keys
+cdm_get_data_model_pks <- function(x) {
+  unclass(x)$data_model_pks
 }
 
-cdm_get_data_model_references <- function(x) {
-  unclass(x)$data_model_references
+cdm_get_data_model_fks <- function(x) {
+  unclass(x)$data_model_fks
 }
 
 #' Get data_model component
@@ -179,14 +179,14 @@ cdm_get_data_model_references <- function(x) {
 #'
 #' @export
 cdm_get_data_model <- function(x) {
-  references_for_columns <- cdm_get_data_model_references(x)
+  references_for_columns <- cdm_get_data_model_fks(x)
 
   references <-
     references_for_columns %>%
     mutate(ref_id = row_number(), ref_col_num = 1L)
 
   keys <-
-    cdm_get_data_model_keys(x) %>%
+    cdm_get_data_model_pks(x) %>%
     mutate(key = 1L)
 
   columns <-

--- a/R/dm.R
+++ b/R/dm.R
@@ -101,6 +101,12 @@ new_dm2 <- function(src = cdm_get_src(base_dm),
                     fks = cdm_get_data_model_fks(base_dm),
                     base_dm) {
 
+  stopifnot(!is.null(src))
+  stopifnot(!is.null(tables))
+  stopifnot(!is.null(data_model_tables))
+  stopifnot(!is.null(pks))
+  stopifnot(!is.null(fks))
+
   structure(
     list(
       src = src,

--- a/R/draw-dm.R
+++ b/R/draw-dm.R
@@ -37,11 +37,10 @@ cdm_draw <- function(
     )
 
     all_table_names <- names(cdm_get_tables(dm))
-    if (!(length(table_names) == length(all_table_names))) {
-      unwanted_tables <- setdiff(all_table_names, table_names)
-      data_model <- rm_table_from_data_model(data_model, unwanted_tables)
-    }
+    unwanted_tables <- setdiff(all_table_names, table_names)
+    data_model <- rm_table_from_data_model(data_model, unwanted_tables)
   }
+
   graph <- dm_create_graph(
     data_model,
     rankdir = rankdir,

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -342,10 +342,10 @@ abort_first_rm_fks <- function(fks) {
 }
 
 error_first_rm_fks <- nse_function(c(fks), ~ {
-  child_tbls <- paste0(pull(fks, child_table), collapse = ", ")
-  parent_tbl <- paste0(unique(pull(fks, parent_table)))
+  child_tbls <- paste0(tick(pull(fks, table)), collapse = ", ")
+  parent_tbl <- tick(pull(fks, table)[[1]])
 
-  glue("There are foreign keys pointing from table(s) ({child_tbls}) to table ({parent_tbl}). First remove those or set 'rm_referencing_fks = TRUE'.")
+  glue("There are foreign keys pointing from table(s) {child_tbls} to table {parent_tbl}. First remove those or set `rm_referencing_fks = TRUE`.")
 })
 
 

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -67,8 +67,8 @@ cdm_has_fk <- function(dm, table, ref_table) {
   check_correct_input(dm, table_name)
   check_correct_input(dm, ref_table_name)
 
-  dm_data_model <- cdm_get_data_model(dm)
-  any(dm_data_model$references$table == table_name & dm_data_model$references$ref == ref_table_name)
+  references <- cdm_get_data_model_references(dm)
+  any(references$table == table_name & references$ref == ref_table_name)
 }
 
 #' Retrieve the name of the column marked as foreign key, pointing from one table of a [`dm`] to another
@@ -100,7 +100,6 @@ cdm_get_fk <- function(dm, table, ref_table) {
 #'
 #' "child_table": child table,
 #' "child_fk_col": foreign key column in child table,
-#' "col_class": class of this column,
 #' "parent_table": parent table,
 #'
 #' @inheritParams cdm_has_fk
@@ -109,41 +108,8 @@ cdm_get_fk <- function(dm, table, ref_table) {
 #'
 #' @export
 cdm_get_all_fks <- nse_function(c(dm), ~ {
-  all_table_names <- src_tbls(dm)
-  all_table_pairings <- crossing(all_table_names, dito = all_table_names) %>%
-    filter(all_table_names != dito)
-
-  vec_1 <- all_table_pairings %>% pull(1)
-  vec_2 <- all_table_pairings %>% pull(2)
-  has_fk <- map2_lgl(vec_1, vec_2, ~ cdm_has_fk(dm, !!.x, !!.y))
-  if (all(has_fk == FALSE)) {
-    tibble(
-      child_table = character(0),
-      child_fk_col = character(0),
-      col_class = character(0),
-      parent_table = character(0)
-    )
-  } else {
-    child_table <- vec_1[has_fk]
-    parent_table <- vec_2[has_fk]
-    child_fk_col <-
-      map2(child_table, parent_table, ~ cdm_get_fk(dm, !!.x, !!.y))
-    # map2_chr() does not work in cases when there is more than 1 FK from one table to another
-
-    tibble(
-      child_table = child_table,
-      child_fk_col = child_fk_col,
-      # col_class = child_fk_col_class,
-      parent_table = parent_table
-    ) %>%
-      unnest(child_fk_col) %>%
-      mutate(col_class = map2_chr(
-        child_table,
-        child_fk_col,
-        ~ get_class_of_table_col(cdm_get_data_model(dm), .x, .y)
-      )) %>%
-      select(child_table, child_fk_col, col_class, parent_table)
-  }
+  cdm_get_data_model_references(dm) %>%
+    select(child_table = table, child_fk_col = column, parent_table = ref)
 })
 
 

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -67,8 +67,8 @@ cdm_has_fk <- function(dm, table, ref_table) {
   check_correct_input(dm, table_name)
   check_correct_input(dm, ref_table_name)
 
-  references <- cdm_get_data_model_references(dm)
-  any(references$table == table_name & references$ref == ref_table_name)
+  fks <- cdm_get_data_model_fks(dm)
+  any(fks$table == table_name & fks$ref == ref_table_name)
 }
 
 #' Retrieve the name of the column marked as foreign key, pointing from one table of a [`dm`] to another
@@ -108,7 +108,7 @@ cdm_get_fk <- function(dm, table, ref_table) {
 #'
 #' @export
 cdm_get_all_fks <- nse_function(c(dm), ~ {
-  cdm_get_data_model_references(dm) %>%
+  cdm_get_data_model_fks(dm) %>%
     select(child_table = table, child_fk_col = column, parent_table = ref)
 })
 

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -201,11 +201,9 @@ cdm_rm_pk <- nse_function(c(dm, table, rm_referencing_fks = FALSE), ~ {
     filter(table != !!table_name)
 
   new_dm2(
-    cdm_get_src(dm),
-    cdm_get_tables(dm),
-    cdm_get_data_model_tables(dm),
-    new_pks,
-    new_fks
+    pks = new_pks,
+    fks = new_fks,
+    base_dm = dm
   )
 })
 

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -144,18 +144,10 @@ cdm_get_pk <- function(dm, table) {
 #' @inheritParams cdm_add_pk
 #'
 #' @export
-cdm_get_all_pks <- function(dm) {
-  all_table_names <- src_tbls(dm)
-  tables_w_pk <- all_table_names[map_lgl(all_table_names, ~ cdm_has_pk(dm, !!.))]
-  pk_names <- map_chr(tables_w_pk, ~ cdm_get_pk(dm, !!.x))
-  pk_classes <- map2_chr(
-    tables_w_pk,
-    pk_names,
-    ~ get_class_of_table_col(cdm_get_data_model(dm), .x, .y)
-  )
-
-  tibble(table = tables_w_pk, pk_col = pk_names, pk_class = pk_classes)
-}
+cdm_get_all_pks <- nse_function(c(dm), ~ {
+  cdm_get_data_model_keys(dm) %>%
+    select(table = table, pk_col = column)
+})
 
 #' Remove primary key from a table in a [`dm`] object
 #'

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -145,7 +145,7 @@ cdm_get_pk <- function(dm, table) {
 #'
 #' @export
 cdm_get_all_pks <- nse_function(c(dm), ~ {
-  cdm_get_data_model_keys(dm) %>%
+  cdm_get_data_model_pks(dm) %>%
     select(table = table, pk_col = column)
 })
 
@@ -180,32 +180,32 @@ cdm_rm_pk <- nse_function(c(dm, table, rm_referencing_fks = FALSE), ~ {
   table_name <- as_name(enquo(table))
   check_correct_input(dm, table_name)
 
-  references <- cdm_get_data_model_references(dm)
-  affected_references <-
-    references %>%
+  fks <- cdm_get_data_model_fks(dm)
+  affected_fks <-
+    fks %>%
     filter(ref == !!table_name)
-  new_references <- references
+  new_fks <- fks
 
-  if (nrow(affected_references) > 0) {
+  if (nrow(affected_fks) > 0) {
     if (rm_referencing_fks) {
-      new_references <-
-        references %>%
+      new_fks <-
+        fks %>%
         filter(ref != !!table_name)
     } else {
-      abort_first_rm_fks(affected_references)
+      abort_first_rm_fks(affected_fks)
     }
   }
 
-  new_keys <-
-    cdm_get_data_model_keys(dm) %>%
+  new_pks <-
+    cdm_get_data_model_pks(dm) %>%
     filter(table != !!table_name)
 
   new_dm2(
     cdm_get_src(dm),
     cdm_get_tables(dm),
     cdm_get_data_model_tables(dm),
-    new_keys,
-    new_references
+    new_pks,
+    new_fks
   )
 })
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,3 +10,7 @@ commas <- function(x) {
 
   glue_collapse(x, sep = ", ")
 }
+
+tick <- function(x) {
+  paste0("`", x, "`")
+}

--- a/man/cdm_get_all_fks.Rd
+++ b/man/cdm_get_all_fks.Rd
@@ -14,7 +14,6 @@ A tibble with columns:
 
 "child_table": child table,
 "child_fk_col": foreign key column in child table,
-"col_class": class of this column,
 "parent_table": parent table,
 }
 \description{

--- a/tests/testthat/test-learn-from-database.R
+++ b/tests/testthat/test-learn-from-database.R
@@ -23,9 +23,6 @@ test_that("Learning from MSSQL works?", {
   data_model_original <-
     cdm_get_data_model(dm_for_filter)
 
-  data_model_original$columns <-
-    set_rownames(data_model_original$columns, 1:15) # for some reason the rownames are the column names...
-
   expect_identical(
     data_model_mssql_learned_renamed_reclassed,
     data_model_original
@@ -45,20 +42,15 @@ test_that("Learning from Postgres works?", {
 
   dm_for_filter_postgres_learned <- cdm_learn_from_db(con_postgres)
 
-  data_model_postgres_learned_renamed_reclassed <-
+  dm_postgres_learned_renamed <-
     cdm_rename_tbl(
       dm_for_filter_postgres_learned,
       structure(src_tbls(dm_for_filter_postgres_learned), names = src_tbls(dm_for_filter))
-    ) %>%
-    cdm_get_data_model() %>%
-    data_model_db_types_to_R_types()
+    )
 
-  data_model_original <-
-    cdm_get_data_model(dm_for_filter)
-
-  expect_identical(
-    data_model_postgres_learned_renamed_reclassed,
-    data_model_original
+  expect_equivalent_dm(
+    dm_postgres_learned_renamed,
+    dm_for_filter
   )
 
   # clean up Postgres-DB


### PR DESCRIPTION
More work needs to be done, along the lines of the commits in this PR. Search for `cdm_get_data_model(` and replace accordingly.

Closes #25.