### PR TITLE
new {datamodelr} print method does not well with tibbles

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -204,7 +204,9 @@ cdm_get_data_model <- function(x) {
     mutate(type = "integer") %>%
     left_join(keys, by = c("table", "column")) %>%
     mutate(key = coalesce(key, 0L)) %>%
-    left_join(references_for_columns, by = c("table", "column"))
+    left_join(references_for_columns, by = c("table", "column")) %>%
+    # for compatibility with print method from {datamodelr}
+    as.data.frame()
 
   new_data_model(
     cdm_get_data_model_tables(x),


### PR DESCRIPTION
``` r
library(tibble)
t <- tibble(a = rep(0, 3))

# result should be 0
length(unique(t[t$a != 0, "a"]))
#> [1] 1
df <- as.data.frame(t)

# this works as intended
length(unique(df[df$a != 0, "a"]))
#> [1] 0
```

<sup>Created on 2019-08-13 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>