### PR TITLE
return named list with `cdm_nrow()`?

### DIFF
--- a/R/filter-helpers.R
+++ b/R/filter-helpers.R
@@ -58,7 +58,7 @@ cdm_update_table <- function(dm, name, table) {
 #' @param dm A [`dm`] object
 #' @export
 cdm_nrow <- function(dm) {
-  sum(map_dbl(cdm_get_tables(dm), ~ as.numeric(pull(collect(count(.))))))
+  map_dbl(cdm_get_tables(dm), ~ as.numeric(pull(collect(count(.)))))
 }
 
 get_by <- function(dm, lhs_name, rhs_name) {

--- a/tests/testthat/test-filter-helper.R
+++ b/tests/testthat/test-filter-helper.R
@@ -2,7 +2,7 @@ test_that("cdm_nrow() works?", {
   map(
     cdm_test_obj_src,
     ~ expect_equal(
-      cdm_nrow(.x) %>% unname(),
+      sum(cdm_nrow(.x)),
       rows_dm_obj
     )
   )


### PR DESCRIPTION
Description of the function promises a named list, but the sum of the row numbers was returned instead.