### PR TITLE
Support numeric subsetting

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -353,10 +353,10 @@ print.dm <- function(x, ...) {
 
 
 #' @export
-`[.dm` <- function(x, name) {
-  if (is.numeric(name)) abort_no_numeric_subsetting()
-  tables <- as_character(name)
-  cdm_select_tbl(x, !!!tables)
+`[.dm` <- function(x, id) {
+  if (is.numeric(id)) id <- src_tbls(x)[id]
+  id <- as_character(id)
+  cdm_select_tbl(x, !!!id)
 }
 
 

--- a/R/dm.R
+++ b/R/dm.R
@@ -341,10 +341,8 @@ print.dm <- function(x, ...) {
 
 
 #' @export
-`[[.dm` <- function(x, name) {
-  if (is.numeric(name)) abort_no_numeric_subsetting()
-  table <- as_string(name)
-  tbl(x, table)
+`[[.dm` <- function(x, id) {
+  cdm_get_tables(x)[[id]]
 }
 
 

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -366,15 +366,6 @@ error_update_not_supported <- function() {
   paste0('Updating "dm" objects not supported.')
 }
 
-abort_no_numeric_subsetting <- function() {
-  abort(error_no_numeric_subsetting(), .subclass = cdm_error_full("no_numeric_subsetting"))
-}
-
-error_no_numeric_subsetting <- function() {
-  paste0("Can't subset a `dm` object by position, either subset by name or use cdm_get_tables() to convert to a regular list first.")
-}
-
-
 # when filters are set and they shouldn't be ------------------------------
 
 abort_only_possible_wo_filters <- function(fun_name) {


### PR DESCRIPTION
support numeric subsetting for
1. `[[.dm()`
1. `[.dm()`


closes #45 