### PR TITLE
reorganize `cdm_flatten()`

### DIFF
--- a/R/data-model-helpers.R
+++ b/R/data-model-helpers.R
@@ -286,6 +286,3 @@ get_all_keys <- function(dm, table_name) {
   c(pk, fks)
 }
 
-are_neighbours <- function(dm, table_1, table_2) {
-  any(c(cdm_has_fk(dm, !!table_1, !!table_2), cdm_has_fk(dm, !!table_2, !!table_1)))
-}

--- a/R/data-model-helpers.R
+++ b/R/data-model-helpers.R
@@ -285,3 +285,7 @@ get_all_keys <- function(dm, table_name) {
   pk <- cdm_get_pk(dm, !!table_name)
   c(pk, fks)
 }
+
+are_neighbours <- function(dm, table_1, table_2) {
+  any(c(cdm_has_fk(dm, !!table_1, !!table_2), cdm_has_fk(dm, !!table_2, !!table_1)))
+}

--- a/R/dm.R
+++ b/R/dm.R
@@ -493,3 +493,10 @@ cdm_rename_tbl <- function(dm, ...) {
     .init = dm
   )
 }
+
+cdm_reset_all_filters <- function(dm) {
+  new_dm2(
+    filter = tibble(table = character(0), filter = list(0)),
+    base_dm = dm
+  )
+}

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -220,12 +220,17 @@ error_txt_no_cycles <- function() {
 
 # errors in cdm_select_tbl() ----------------------------------------------
 
-abort_vertices_not_connected <- function(fun_name) {
-  abort(error_txt_vertices_not_connected(fun_name), .subclass = cdm_error_full("vertices_not_connected"))
+abort_vertices_not_connected <- function(fun_name, param = NULL) {
+  abort(error_txt_vertices_not_connected(fun_name, param), .subclass = cdm_error_full("vertices_not_connected"))
 }
 
-error_txt_vertices_not_connected <- function(fun_name) {
-  glue("For `{fun_name}()` all of the selected tables of the `dm`-object need to be connected.")
+error_txt_vertices_not_connected <- function(fun_name, param) {
+  if (is_null(param)) {
+    glue("For `{fun_name}()` all of the selected tables of the `dm`-object need to be connected.")
+  } else {
+    glue("All selected tables in parameter `{param}` of `{fun_name}()` need to be connected (no missing links).")
+  }
+
 }
 
 

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -360,3 +360,15 @@ abort_tables_not_neighbours <- function(t1_name, t2_name) {
 error_tables_not_neighbours <- function(t1_name, t2_name) {
   glue("Tables `{t1_name}` and `{t2_name}` are not directly linked by a foreign key relation.")
 }
+
+# `right_join()` might produce random result for `cdm_flatten_to_tbl()`
+
+abort_rj_not_wd <- function() {
+  abort(error_rj_not_wd(), .subclass = cdm_error_full("_rj_not_wd"))
+}
+
+error_rj_not_wd <- function() {
+  paste0("No well-defined result, when using `cdm_flatten_to_tbl()` with `right_join()` ",
+         "with more than 2 tables involved (depends on order of tables in `dm`)")
+}
+

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -364,7 +364,7 @@ error_tables_not_neighbours <- function(t1_name, t2_name) {
 # `right_join()` might produce random result for `cdm_flatten_to_tbl()`
 
 abort_rj_not_wd <- function() {
-  abort(error_rj_not_wd(), .subclass = cdm_error_full("_rj_not_wd"))
+  abort(error_rj_not_wd(), .subclass = cdm_error_full("rj_not_wd"))
 }
 
 error_rj_not_wd <- function() {
@@ -372,3 +372,13 @@ error_rj_not_wd <- function() {
          "with more than 2 tables involved (depends on order of tables in `dm`)")
 }
 
+# `semi_join()` and `anti_join()` not supported for `cdm_flatten_to_tbl()` for deep hierarchy
+
+abort_semi_anti_nys <- function() {
+  abort(error_semi_anti_nys(), .subclass = cdm_error_full("semi_anti_nys"))
+}
+
+error_semi_anti_nys <- function() {
+  paste0("When flattening a `dm` with `semi_join()` or `anti_join()` all tables have to be ",
+  "directly connected to table `start` (at least currently).")
+}

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -380,5 +380,5 @@ abort_semi_anti_nys <- function() {
 
 error_semi_anti_nys <- function() {
   paste0("When flattening a `dm` with `semi_join()` or `anti_join()` all tables have to be ",
-  "directly connected to table `start` (at least currently).")
+  "directly connected to table `start`.")
 }

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -3,19 +3,23 @@
 #' This function joins all the tables of your [`dm`] object together, that can be reached
 #' from table `start` in the direction that the foreign keys are pointing, using the
 #' foreign key relations to determine the parameter `by` for the necessary joins.
-#' It returns one table with unique columns. Use [cdm_select_tbl()] if necessary to
-#' reduce the number of tables before calling this function.
+#' It returns one table with unique columns. Use the `...` if necessary to
+#' reduce the number of tables that should be included in the result.
 #'
 #' @inheritParams cdm_join_to_tbl
 #' @param start Table to start from. From this table all outgoing foreign key relations are
 #' considered to establish a processing order for the joins. An interesting choice could be
 #' for example a fact table in a star schema.
+#' @param ... Unquoted table names to include in addition to `start`. If empty, all tables that can
+#' be reached are included.
 #' @family flattening functions
 #'
-#' @details Uses [`cdm_apply_filters()`] and [`cdm_disambiguate_cols()`] first, to
-#' get a "clean" [`dm`]. Subsequently renames all foreign key columns to the names of
-#' the primary key columns they are pointing to. Then the order of the joins is determined
-#' and the joins are performed.
+#' @details Applied the necessary filters (in any case the cascading effect of the filters on `start`
+#' is taken into account) and [`cdm_disambiguate_cols()`] first, to get a "clean" [`dm`].
+#' Then the order of the joins is determined and the joins are performed.
+#'
+#' Mind, that for `join = right_join` the result two or more consecutive joins depends on the order
+#' of the joins and eventually on the order of the table in the `dm`.
 #'
 #' @return A wide table resulting of consecutively joining all tables together.
 #'

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -135,7 +135,8 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
   # FIXME: so far there is a problem with `semi_join` and `anti_join`, when one of the
   # included tables has a distance of 2 or more to `start`, because then the required
   # column for `by` on the LHS is missing
-  if (!gotta_rename && !all(map_lgl(order_df$name, ~are_neighbours(clean_dm, start, .)))) {
+  if (!gotta_rename && !all(map_lgl(order_df$name, ~{
+    cdm_has_fk(clean_dm, !!start, !!.) || cdm_has_fk(clean_dm, !!., !!start)}))) {
     abort_semi_anti_nys()
   }
 
@@ -172,7 +173,7 @@ cdm_join_to_tbl <- function(dm, table_1, table_2, join = left_join) {
   t1_name <- as_string(ensym(table_1))
   t2_name <- as_string(ensym(table_2))
 
-  if (!are_neighbours(dm, t1_name, t2_name)) {
+  if (!(cdm_has_fk(dm, {{ t1_name }}, {{ t2_name }}) || cdm_has_fk(dm, {{ t2_name }}, {{ t1_name }}))) {
     abort_tables_not_neighbours(t1_name, t2_name)
   }
   start <- child_table(dm, {{ table_1 }}, {{ table_2 }})

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -33,6 +33,9 @@
 #' table would depend on the order the tables are listed in the `dm`. Therefore trying this results
 #' in an error.
 #'
+#' Currently, it is not possible to use `semi_join` or `anti_join` as join-methods in the case of an
+#' unfiltered `dm`, when not all involved foreign tables are directly connected to table `start`.
+#'
 #' @return A wide table resulting of consecutively joining all tables involved to table `start`.
 #'
 #' @examples

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -74,7 +74,7 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
 
   if (any_filter_in_conn_comp) {
     if (join_name == "semi_join") return(tbl(dm, start))
-    if (join_name == "anti_join") return(tbl(dm, start) %>% filter(FALSE))
+    if (join_name == "anti_join") return(cdm_get_tables(dm)[[start]] %>% filter(1 == 0))
     message("Using default `left_join()`, since filter conditions are set and `join` ",
             "neither `semi_join()` nor `anti_join()`.")
     join <- left_join

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -15,15 +15,17 @@
 #' be reached are included.
 #' @family flattening functions
 #'
-#' @details **Case 1**, no filters conditions are set in the `dm`:
-#' The necessary disambiguations of the column names are performed first. Then all involved foreign tables
-#' are joined to table `start` successively with the join function given in parameter `join`.
+#' @details **Case 1**, either no filter conditions are set in the `dm`, or only in a part unconnected to
+#' table `start`:
+#' The necessary disambiguations of the column names are performed first. Then all
+#' involved foreign tables are joined to table `start` successively with the join function given in
+#' parameter `join`.
 #'
-#' **Case 2**, filter conditions are set:
+#' **Case 2**, filter conditions are set for at least one table connected to `start`:
 #' The result of filtering a `dm` object is necessarily a data model conforming to referential integrity.
 #' Consequently, there is no difference between `left_join`, `right_join`, `inner_join` and `full_join`.
 #' In this case, `left_join` is being used. Using `semi_join` in `cdm_flatten_to_tbl()` on a filtered `dm`
-#' is identical to `tbl(dm, start)`, `anti_join` is identical to `tbl(dm, start) %>% filter(FALSE)`.
+#' is identical to `tbl(dm, start)`, and `anti_join` is identical to `tbl(dm, start) %>% filter(FALSE)`.
 #' Disambiguation is performed initially if necessary.
 #'
 #' Mind, that calling `cdm_flatten_to_tbl()` on an unfiltered `dm` with `join = right_join` would not lead

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -1,10 +1,11 @@
 #' Flatten part of a `dm` into a wide table
 #'
-#' This function joins all the tables of your [`dm`] object together, that can be reached
-#' from table `start` in the direction that the foreign keys are pointing, using the
-#' foreign key relations to determine the parameter `by` for the necessary joins.
-#' It returns one table with unique columns. Use the `...` if necessary to
-#' reduce the number of tables that should be included in the result.
+#' With the `...` left empty, this function joins all the tables of your [`dm`]
+#' object together, that can be reached from table `start` in the direction of the foreign
+#' key relations (pointing from child table to parent table), using the foreign key relations to
+#' determine the parameter `by` for the necessary joins.
+#' The result is one table with unique column names.
+#' Use the `...` if you want to control which tables should be joined to table `start`.
 #'
 #' @inheritParams cdm_join_to_tbl
 #' @param start Table to start from. From this table all outgoing foreign key relations are
@@ -14,14 +15,23 @@
 #' be reached are included.
 #' @family flattening functions
 #'
-#' @details Applied the necessary filters (in any case the cascading effect of the filters on `start`
-#' is taken into account) and [`cdm_disambiguate_cols()`] first, to get a "clean" [`dm`].
-#' Then the order of the joins is determined and the joins are performed.
+#' @details **Case 1**, no filters conditions are set in the `dm`:
+#' The necessary disambiguations of the column names are performed first. Then all involved foreign tables
+#' are joined to table `start` successively with the join function given in parameter `join`.
 #'
-#' Mind, that for `join = right_join` the result two or more consecutive joins depends on the order
-#' of the joins and eventually on the order of the table in the `dm`.
+#' **Case 2**, filter conditions are set:
+#' The result of filtering a `dm` object is necessarily a data model conforming to referential integrity.
+#' Consequently, there is no difference between `left_join`, `right_join`, `inner_join` and `full_join`.
+#' In this case, `left_join` is being used. Using `semi_join` in `cdm_flatten_to_tbl()` on a filtered `dm`
+#' is identical to `tbl(dm, start)`, `anti_join` is identical to `tbl(dm, start) %>% filter(FALSE)`.
+#' Disambiguation is performed initially if necessary.
 #'
-#' @return A wide table resulting of consecutively joining all tables together.
+#' Mind, that calling `cdm_flatten_to_tbl()` on an unfiltered `dm` with `join = right_join` would not lead
+#' to a well-defined result, if two or more foreign tables are to be joined to `start`. The resulting
+#' table would depend on the order the tables are listed in the `dm`. Therefore trying this results
+#' in an error.
+#'
+#' @return A wide table resulting of consecutively joining all tables involved to table `start`.
 #'
 #' @examples
 #' cdm_nycflights13() %>%

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -39,10 +39,10 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name = NULL) {
 
   force(join)
   stopifnot(is_function(join))
-  if (is_null(join_name)) join_name <- deparse(substitute(join))
-  # early returns for some of the possible joins:
-  if (join_name == "semi_join") return(tbl(dm, start))
-  if (join_name == "anti_join") return(tbl(dm, start) %>% filter(FALSE))
+  # early returns for some of the possible joins would be possible for "perfect" key relations,
+  # but since it is possible to have imperfect FK relations, `semi_join` and `anti_join` might
+  # produce results, that are of interest, e.g.
+  # cdm_flatten_to_tbl(cdm_nycflights13(cycle = TRUE) %>% cdm_rm_fk(flights, origin, airports), flights, airports, join = anti_join)
 
   # need to work with directed graph here, since we only want to go in the direction
   # the foreign key is pointing to

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -119,6 +119,11 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
   # filters need to be empty, for the disambiguation to work
   # the renaming will be minimized, if we reduce the `dm` to the necessary tables here
   red_dm <- cdm_reset_all_filters(dm) %>% cdm_select_tbl(order_df$name)
+
+  # if tables in the ellipsis aren't connected without missing links, throw an error
+  if (!all(map_lgl(order_df$name, ~are_tables_connected(red_dm, start, .x)))) {
+    abort_vertices_not_connected("cdm_flatten_to_tbl", "...")
+  }
   if (gotta_rename) {
     recipe <- compute_disambiguate_cols_recipe(red_dm, order_df$name, sep = ".")
     explain_col_rename(recipe)

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -1,11 +1,12 @@
 #' Flatten part of a `dm` into a wide table
 #'
-#' With the `...` left empty, this function joins all the tables of your [`dm`]
-#' object together, that can be reached from table `start` in the direction of the foreign
-#' key relations (pointing from child table to parent table), using the foreign key relations to
-#' determine the parameter `by` for the necessary joins.
-#' The result is one table with unique column names.
-#' Use the `...` if you want to control which tables should be joined to table `start`.
+#' Gather all information of interest in one place in a wide table (on a database-[`dm`] a
+#' temporary table will be created).
+#' If referential integrity is given among the tables of the data model, the resulting
+#' table of this function will contain as many rows as the table `start` does (exceptions are
+#' `join = anti_join` (result is empty table with same columns as `start`) and `join = right_join` (
+#' number of rows equal to those of the join-partner of `start`)).
+#' For more information please refer to `vignette("dm-joining")`.
 #'
 #' @inheritParams cdm_join_to_tbl
 #' @param start Table to start from. From this table all outgoing foreign key relations are
@@ -15,7 +16,16 @@
 #' be reached are included.
 #' @family flattening functions
 #'
-#' @details **Case 1**, either no filter conditions are set in the `dm`, or only in a part unconnected to
+#' @details With the `...` left empty, this function joins all the tables of your [`dm`]
+#' object together, that can be reached from table `start` in the direction of the foreign
+#' key relations (pointing from child table to parent table), using the foreign key relations to
+#' determine the parameter `by` for the necessary joins.
+#' The result is one table with unique column names.
+#' Use the `...` if you want to control which tables should be joined to table `start`.
+#'
+#' How does filtering affects the result?
+#'
+#' **Case 1**, either no filter conditions are set in the `dm`, or only in a part unconnected to
 #' table `start`:
 #' The necessary disambiguations of the column names are performed first. Then all
 #' involved foreign tables are joined to table `start` successively with the join function given in
@@ -25,7 +35,7 @@
 #' The result of filtering a `dm` object is necessarily a data model conforming to referential integrity.
 #' Consequently, there is no difference between `left_join`, `right_join`, `inner_join` and `full_join`.
 #' In this case, `left_join` is being used. Using `semi_join` in `cdm_flatten_to_tbl()` on a filtered `dm`
-#' is identical to `tbl(dm, start)`, and `anti_join` is identical to `tbl(dm, start) %>% filter(FALSE)`.
+#' is identical to `tbl(dm, start)`, and `anti_join` is identical to `tbl(dm, start) %>% filter(1 == 0)`.
 #' Disambiguation is performed initially if necessary.
 #'
 #' Mind, that calling `cdm_flatten_to_tbl()` on an unfiltered `dm` with `join = right_join` would not lead

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -83,9 +83,7 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
   # the result for `right_join()` depends on the order of the dim-tables in the `dm`
   # if 2 or more of them are joined to the fact table. If filter conditions are set,
   # it does not play a role.
-  if (join_name == "right_join" && nrow(order_df) > 2 && !are_filters_set) warning(
-    "When using `cdm_flatten_to_tbl()` with `right_join()`, the result will generally ",
-           "depend on which foreign table is joined last to `start`.")
+  if (join_name == "right_join" && nrow(order_df) > 2 && !are_filters_set) abort_rj_not_wd()
 
   # filters need to be empty, for the disambiguation to work
   # the renaming will be minimized, if we reduce the `dm` to the necessary tables here

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -114,8 +114,7 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
   order_df <- order_df[-1, ]
 
   # list of join partners
-  filtered_tables <- clean_dm %>% cdm_get_tables()
-  ordered_table_list <- filtered_tables[order_df$name]
+  ordered_table_list <- clean_dm %>% cdm_get_tables() %>% extract(order_df$name)
   by <- map2(order_df$pred, order_df$name, ~ get_by(dm, .x, .y))
 
   # perform the joins according to the list, starting with table `initial_LHS`

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -99,7 +99,7 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
       name = names(dfs[["order"]]),
       pred = names(V(g))[ unclass(dfs[["father"]])[name] ]
     ) %>%
-    filter(!is.na(name), name %in% c(start, list_of_pts))
+    filter(name %in% c(start, list_of_pts))
 
   # the result for `right_join()` depends on the order of the dim-tables in the `dm`
   # if 2 or more of them are joined to the fact table. If filter conditions are set,

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -25,12 +25,13 @@
 #'   cdm_flatten_to_tbl(flights)
 #' @export
 cdm_flatten_to_tbl <- function(dm, start, ..., join = left_join) {
-  cdm_flatten_to_tbl_impl(dm, start, ..., join = join)
+  join_name <- deparse(substitute(join))
+  start <- as_string(ensym(start))
+  cdm_flatten_to_tbl_impl(dm, start, ..., join = join, join_name = join_name)
 }
 
-cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name = NULL) {
+cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
 
-  start <- as_name(ensym(start))
   check_correct_input(dm, start)
   list_of_pts <- as.character(enexprs(...))
   walk(list_of_pts, ~check_correct_input(dm, .))
@@ -132,7 +133,7 @@ cdm_join_to_tbl <- function(dm, table_1, table_2, join = left_join) {
   start <- child_table(dm, {{ table_1 }}, {{ table_2 }})
   other <- setdiff(c(t1_name, t2_name), start)
 
-  cdm_flatten_to_tbl_impl(dm, !!start, !!other, join = join, join_name = join_name)
+  cdm_flatten_to_tbl_impl(dm, start, !!other, join = join, join_name = join_name)
 }
 
 child_table <- function(dm, table_1, table_2) {

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -129,6 +129,13 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
   # in the case of only one table in the `dm` (table "start"), all code below is a no-op
   order_df <- order_df[-1, ]
 
+  # FIXME: so far there is a problem with `semi_join` and `anti_join`, when one of the
+  # included tables has a distance of 2 or more to `start`, because then the required
+  # column for `by` on the LHS is missing
+  if (!gotta_rename && !all(map_lgl(order_df$name, ~are_neighbours(clean_dm, start, .)))) {
+    abort_semi_anti_nys()
+  }
+
   # list of join partners
   ordered_table_list <- clean_dm %>% cdm_get_tables() %>% extract(order_df$name)
   by <- map2(order_df$pred, order_df$name, ~ get_by(dm, .x, .y))

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -30,6 +30,10 @@ cdm_flatten_to_tbl <- function(dm, start, join = left_join) {
 
   force(join)
   stopifnot(is_function(join))
+  join_name <- deparse(substitute(join))
+  # early returns for some of the possible joins:
+  if (join_name == "semi_join") return(tbl(dm, start))
+  if (join_name == "anti_join") return(tbl(dm, start) %>% filter(FALSE))
 
   # need to work with directed graph here, since we only want to go in the direction
   # the foreign key is pointing to

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -23,7 +23,7 @@
 #' The result is one table with unique column names.
 #' Use the `...` if you want to control which tables should be joined to table `start`.
 #'
-#' How does filtering affects the result?
+#' How does filtering affect the result?
 #'
 #' **Case 1**, either no filter conditions are set in the `dm`, or only in a part unconnected to
 #' table `start`:

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -78,9 +78,8 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
   # 1. left_join(), right_join(), full_join(), inner_join() will produce the same results
   # 2. semi_join() will be equal to `tbl(dm, start)`
   # 3. anti_join() will be equal to `tbl(dm, start) %>% filter(FALSE)`
-  any_filter_in_conn_comp <- any(
-    map_lgl(pull(cdm_get_filter(dm), table), ~are_tables_connected(dm, start, .x))
-    )
+  # FIXME: improve `is_any_filter_conn_to_tbl()`
+  any_filter_in_conn_comp <- is_any_filter_conn_to_tbl(dm, start)
 
   if (any_filter_in_conn_comp) {
     if (join_name == "semi_join") return(tbl(dm, start))

--- a/R/graph.R
+++ b/R/graph.R
@@ -92,9 +92,22 @@ is_dm_connected <- nse_function(c(dm), ~ {
   V <- names(V(g))
 
   vertex_names[1] %in% V &&
-    igraph::bfs(g, vertex_names[1], father = TRUE, rank = TRUE, unreachable = FALSE) %>%
-      extract2("order") %>%
-      names() %>%
+    get_names_of_connected(g, vertex_names[1]) %>%
       is_in(vertex_names, .) %>%
       all()
 })
+
+are_tables_connected <- function(dm, t1_name, t2_name) {
+  walk(c(t1_name, t2_name), ~check_correct_input(dm, .))
+  g <- create_graph_from_dm(dm)
+  V <- names(V(g))
+
+  conn_tbls <- get_names_of_connected(g, t1_name)
+  t2_name %in% conn_tbls
+}
+
+get_names_of_connected <- function(g, start) {
+  igraph::bfs(g, start, unreachable = FALSE) %>%
+    extract2("order") %>%
+    names()
+}

--- a/R/graph.R
+++ b/R/graph.R
@@ -111,3 +111,10 @@ get_names_of_connected <- function(g, start) {
     extract2("order") %>%
     names()
 }
+
+is_any_filter_conn_to_tbl <- function(dm, tbl) {
+  any(map_lgl(
+    pull(cdm_get_filter(dm), table),
+    ~ are_tables_connected(dm, tbl, .x)
+  ))
+}

--- a/man/cdm_flatten_to_tbl.Rd
+++ b/man/cdm_flatten_to_tbl.Rd
@@ -19,22 +19,32 @@ be reached are included.}
 \item{join}{The type of join to be performed, see \code{\link[dplyr:join]{dplyr::join()}}}
 }
 \value{
-A wide table resulting of consecutively joining all tables together.
+A wide table resulting of consecutively joining all tables involved to table \code{start}.
 }
 \description{
-This function joins all the tables of your \code{\link{dm}} object together, that can be reached
-from table \code{start} in the direction that the foreign keys are pointing, using the
-foreign key relations to determine the parameter \code{by} for the necessary joins.
-It returns one table with unique columns. Use the \code{...} if necessary to
-reduce the number of tables that should be included in the result.
+With the \code{...} left empty, this function joins all the tables of your \code{\link{dm}}
+object together, that can be reached from table \code{start} in the direction of the foreign
+key relations (pointing from child table to parent table), using the foreign key relations to
+determine the parameter \code{by} for the necessary joins.
+The result is one table with unique column names.
+Use the \code{...} if you want to control which tables should be joined to table \code{start}.
 }
 \details{
-Applied the necessary filters (in any case the cascading effect of the filters on \code{start}
-is taken into account) and \code{\link[=cdm_disambiguate_cols]{cdm_disambiguate_cols()}} first, to get a "clean" \code{\link{dm}}.
-Then the order of the joins is determined and the joins are performed.
+\strong{Case 1}, no filters conditions are set in the \code{dm}:
+The necessary disambiguations of the column names are performed first. Then all involved foreign tables
+are joined to table \code{start} successively with the join function given in parameter \code{join}.
 
-Mind, that for \code{join = right_join} the result two or more consecutive joins depends on the order
-of the joins and eventually on the order of the table in the \code{dm}.
+\strong{Case 2}, filter conditions are set:
+The result of filtering a \code{dm} object is necessarily a data model conforming to referential integrity.
+Consequently, there is no difference between \code{left_join}, \code{right_join}, \code{inner_join} and \code{full_join}.
+In this case, \code{left_join} is being used. Using \code{semi_join} in \code{cdm_flatten_to_tbl()} on a filtered \code{dm}
+is identical to \code{tbl(dm, start)}, \code{anti_join} is identical to \code{tbl(dm, start) \%>\% filter(FALSE)}.
+Disambiguation is performed initially if necessary.
+
+Mind, that calling \code{cdm_flatten_to_tbl()} on an unfiltered \code{dm} with \code{join = right_join} would not lead
+to a well-defined result, if two or more foreign tables are to be joined to \code{start}. The resulting
+table would depend on the order the tables are listed in the \code{dm}. Therefore trying this results
+in an error.
 }
 \examples{
 cdm_nycflights13() \%>\%

--- a/man/cdm_flatten_to_tbl.Rd
+++ b/man/cdm_flatten_to_tbl.Rd
@@ -4,7 +4,7 @@
 \alias{cdm_flatten_to_tbl}
 \title{Flatten part of a \code{dm} into a wide table}
 \usage{
-cdm_flatten_to_tbl(dm, start, join = left_join)
+cdm_flatten_to_tbl(dm, start, ..., join = left_join)
 }
 \arguments{
 \item{dm}{A \code{\link{dm}} object}
@@ -12,6 +12,9 @@ cdm_flatten_to_tbl(dm, start, join = left_join)
 \item{start}{Table to start from. From this table all outgoing foreign key relations are
 considered to establish a processing order for the joins. An interesting choice could be
 for example a fact table in a star schema.}
+
+\item{...}{Unquoted table names to include in addition to \code{start}. If empty, all tables that can
+be reached are included.}
 
 \item{join}{The type of join to be performed, see \code{\link[dplyr:join]{dplyr::join()}}}
 }
@@ -22,14 +25,16 @@ A wide table resulting of consecutively joining all tables together.
 This function joins all the tables of your \code{\link{dm}} object together, that can be reached
 from table \code{start} in the direction that the foreign keys are pointing, using the
 foreign key relations to determine the parameter \code{by} for the necessary joins.
-It returns one table with unique columns. Use \code{\link[=cdm_select_tbl]{cdm_select_tbl()}} if necessary to
-reduce the number of tables before calling this function.
+It returns one table with unique columns. Use the \code{...} if necessary to
+reduce the number of tables that should be included in the result.
 }
 \details{
-Uses \code{\link[=cdm_apply_filters]{cdm_apply_filters()}} and \code{\link[=cdm_disambiguate_cols]{cdm_disambiguate_cols()}} first, to
-get a "clean" \code{\link{dm}}. Subsequently renames all foreign key columns to the names of
-the primary key columns they are pointing to. Then the order of the joins is determined
-and the joins are performed.
+Applied the necessary filters (in any case the cascading effect of the filters on \code{start}
+is taken into account) and \code{\link[=cdm_disambiguate_cols]{cdm_disambiguate_cols()}} first, to get a "clean" \code{\link{dm}}.
+Then the order of the joins is determined and the joins are performed.
+
+Mind, that for \code{join = right_join} the result two or more consecutive joins depends on the order
+of the joins and eventually on the order of the table in the \code{dm}.
 }
 \examples{
 cdm_nycflights13() \%>\%

--- a/man/cdm_flatten_to_tbl.Rd
+++ b/man/cdm_flatten_to_tbl.Rd
@@ -30,15 +30,17 @@ The result is one table with unique column names.
 Use the \code{...} if you want to control which tables should be joined to table \code{start}.
 }
 \details{
-\strong{Case 1}, no filters conditions are set in the \code{dm}:
-The necessary disambiguations of the column names are performed first. Then all involved foreign tables
-are joined to table \code{start} successively with the join function given in parameter \code{join}.
+\strong{Case 1}, either no filter conditions are set in the \code{dm}, or only in a part unconnected to
+table \code{start}:
+The necessary disambiguations of the column names are performed first. Then all
+involved foreign tables are joined to table \code{start} successively with the join function given in
+parameter \code{join}.
 
-\strong{Case 2}, filter conditions are set:
+\strong{Case 2}, filter conditions are set for at least one table connected to \code{start}:
 The result of filtering a \code{dm} object is necessarily a data model conforming to referential integrity.
 Consequently, there is no difference between \code{left_join}, \code{right_join}, \code{inner_join} and \code{full_join}.
 In this case, \code{left_join} is being used. Using \code{semi_join} in \code{cdm_flatten_to_tbl()} on a filtered \code{dm}
-is identical to \code{tbl(dm, start)}, \code{anti_join} is identical to \code{tbl(dm, start) \%>\% filter(FALSE)}.
+is identical to \code{tbl(dm, start)}, and \code{anti_join} is identical to \code{tbl(dm, start) \%>\% filter(FALSE)}.
 Disambiguation is performed initially if necessary.
 
 Mind, that calling \code{cdm_flatten_to_tbl()} on an unfiltered \code{dm} with \code{join = right_join} would not lead

--- a/man/cdm_flatten_to_tbl.Rd
+++ b/man/cdm_flatten_to_tbl.Rd
@@ -22,14 +22,24 @@ be reached are included.}
 A wide table resulting of consecutively joining all tables involved to table \code{start}.
 }
 \description{
+Gather all information of interest in one place in a wide table (on a database-\code{\link{dm}} a
+temporary table will be created).
+If referential integrity is given among the tables of the data model, the resulting
+table of this function will contain as many rows as the table \code{start} does (exceptions are
+\code{join = anti_join} (result is empty table with same columns as \code{start}) and \code{join = right_join} (
+number of rows equal to those of the join-partner of \code{start})).
+For more information please refer to \code{vignette("dm-joining")}.
+}
+\details{
 With the \code{...} left empty, this function joins all the tables of your \code{\link{dm}}
 object together, that can be reached from table \code{start} in the direction of the foreign
 key relations (pointing from child table to parent table), using the foreign key relations to
 determine the parameter \code{by} for the necessary joins.
 The result is one table with unique column names.
 Use the \code{...} if you want to control which tables should be joined to table \code{start}.
-}
-\details{
+
+How does filtering affects the result?
+
 \strong{Case 1}, either no filter conditions are set in the \code{dm}, or only in a part unconnected to
 table \code{start}:
 The necessary disambiguations of the column names are performed first. Then all
@@ -40,7 +50,7 @@ parameter \code{join}.
 The result of filtering a \code{dm} object is necessarily a data model conforming to referential integrity.
 Consequently, there is no difference between \code{left_join}, \code{right_join}, \code{inner_join} and \code{full_join}.
 In this case, \code{left_join} is being used. Using \code{semi_join} in \code{cdm_flatten_to_tbl()} on a filtered \code{dm}
-is identical to \code{tbl(dm, start)}, and \code{anti_join} is identical to \code{tbl(dm, start) \%>\% filter(FALSE)}.
+is identical to \code{tbl(dm, start)}, and \code{anti_join} is identical to \code{tbl(dm, start) \%>\% filter(1 == 0)}.
 Disambiguation is performed initially if necessary.
 
 Mind, that calling \code{cdm_flatten_to_tbl()} on an unfiltered \code{dm} with \code{join = right_join} would not lead

--- a/man/cdm_flatten_to_tbl.Rd
+++ b/man/cdm_flatten_to_tbl.Rd
@@ -38,7 +38,7 @@ determine the parameter \code{by} for the necessary joins.
 The result is one table with unique column names.
 Use the \code{...} if you want to control which tables should be joined to table \code{start}.
 
-How does filtering affects the result?
+How does filtering affect the result?
 
 \strong{Case 1}, either no filter conditions are set in the \code{dm}, or only in a part unconnected to
 table \code{start}:

--- a/man/cdm_flatten_to_tbl.Rd
+++ b/man/cdm_flatten_to_tbl.Rd
@@ -47,6 +47,9 @@ Mind, that calling \code{cdm_flatten_to_tbl()} on an unfiltered \code{dm} with \
 to a well-defined result, if two or more foreign tables are to be joined to \code{start}. The resulting
 table would depend on the order the tables are listed in the \code{dm}. Therefore trying this results
 in an error.
+
+Currently, it is not possible to use \code{semi_join} or \code{anti_join} as join-methods in the case of an
+unfiltered \code{dm}, when not all involved foreign tables are directly connected to table \code{start}.
 }
 \examples{
 cdm_nycflights13() \%>\%

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -1,9 +1,10 @@
 try(library(dbplyr), silent = TRUE)
 library(rprojroot)
+library(nycflights13)
 
 # for check_cardinality...() ----------------------------------------------
 
-message("for ccheck_cardinality...()")
+message("for check_cardinality...()")
 
 d1 <- tibble::tibble(a = 1:5, b = letters[1:5])
 d2 <- tibble::tibble(a = c(1, 3:6), b = letters[1:5])

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -420,6 +420,7 @@ if (is_this_a_test()) {
   dm_for_filter_w_cycle_src <- cdm_test_load(dm_for_filter_w_cycle)
   cdm_test_obj_src <- cdm_test_load(cdm_test_obj)
   dm_for_flatten_src <- cdm_test_load(dm_for_flatten)
+  dm_more_complex_src <- cdm_test_load(dm_more_complex)
 
   d1_src <- test_load(d1)
   d2_src <- test_load(d2)

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -1,6 +1,5 @@
 try(library(dbplyr), silent = TRUE)
 library(rprojroot)
-library(nycflights13)
 
 # for check_cardinality...() ----------------------------------------------
 
@@ -378,6 +377,8 @@ clear_postgres <- function() {
 
 # Only run if the top level call is devtools::test() or testthat::test_check()
 if (is_this_a_test()) {
+  library(nycflights13)
+
   message("connecting")
 
   test_register_src("df", src_df(env = new_environment()))

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -99,3 +99,39 @@ test_that("`cdm_flatten_to_tbl()` does the right thing for 'right_join()'", {
 
   })
 
+test_that("`cdm_flatten_to_tbl()` does the right thing for filtered `dm`s", {
+
+  walk(dm_more_complex_src,
+       ~expect_equivalent(
+         cdm_flatten_to_tbl(cdm_filter(., t1, a > 5), t5) %>% collect(),
+         tibble(k = 2:4, l = letters[3:5], m = c("tree", rep("streetlamp", 2)),
+                i = c("five", "six", "seven"), j = c("E", "F", "F"), g = c("four", rep("five", 2)),
+                o = c("f", "h", "h"), s = i, t = c("E", "F", "G"))
+       )
+  )
+
+  walk(dm_more_complex_src,
+       ~expect_equivalent(
+         cdm_flatten_to_tbl(cdm_filter(., t1, a > 5), t5, join = semi_join) %>% collect(),
+         slice(t5, 2:4)
+       )
+  )
+
+  walk(dm_more_complex_src,
+       ~expect_equivalent(
+         cdm_flatten_to_tbl(cdm_filter(., b, b_3 > 7), t5) %>% collect(),
+         tibble(k = 1:4, l = letters[2:5], m = c("house", "tree", rep("streetlamp", 2)),
+                i = c("four", "five", "six", "seven"), j = c("D", "E", "F", "F"),
+                g = c("three", "four", rep("five", 2)), o = c("e", "f", "h", "h"),
+                s = c("three", "five", "six", "seven"), t = c("D", "E", "F", "G"))
+       )
+  )
+
+  # this is NYI for anti_join and semi_join:
+  walk(dm_more_complex_src,
+       ~expect_error(
+         cdm_flatten_to_tbl(cdm_filter(., b, b_3 > 7), t5, join = semi_join) %>% collect(),
+         class = cdm_error("semi_anti_nys")
+       )
+  )
+})

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -134,4 +134,21 @@ test_that("`cdm_flatten_to_tbl()` does the right thing for filtered `dm`s", {
          class = cdm_error("semi_anti_nys")
        )
   )
+
+})
+
+test_that("`cdm_flatten_to_tbl()` throws right errors", {
+  walk(dm_more_complex_src,
+       ~expect_error(
+         cdm_flatten_to_tbl(., t5, t6, t3),
+         class = cdm_error("vertices_not_connected")
+       )
+  )
+
+  walk(dm_for_filter_src,
+       ~expect_error(
+         cdm_flatten_to_tbl(., t5, join = right_join),
+         class = cdm_error("rj_not_wd")
+       )
+  )
 })

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -32,10 +32,11 @@ test_that("`cdm_flatten_to_tbl()` does the right thing for a one-table-dm", {
 test_that("`cdm_flatten_to_tbl()` does the right thing for 'right_join()'", {
   map(
     # sqlite: RIGHT and FULL OUTER JOINs are not currently supported
-    dm_for_flatten_src[setdiff(names(dm_for_flatten_src), "sqlite")],
+    # yet, here we eventually use `left_join()` anyway
+    dm_for_flatten_src,
     ~ expect_equivalent(
       cdm_flatten_to_tbl(cdm_filter(.x, dim_1, dim_1_pk > 4), fact, dim_1, join = right_join) %>% collect(),
-      right_join(fact, filter(dim_1, dim_1_pk > 4), by = c("dim_1_key" = "dim_1_pk")) %>%
+      left_join(fact, filter(dim_1, dim_1_pk > 4), by = c("dim_1_key" = "dim_1_pk")) %>%
         rename(fact.something = something.x, dim_1.something = something.y)
     )
   )

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -41,20 +41,33 @@ test_that("`cdm_flatten_to_tbl()` does the right thing for 'right_join()'", {
     )
   )
 
-  # It might be expected, that if the user choses a `right_join()`, `full_join()`, `semi_join()` or
-  # `anti_join()`, he expects only the direct effect of filter conditions on dimension tables
-  # to take an effect (so `dim_1, dim_1_pk > 4` has only an effect on table `dim_1` and no cascading effect);
-  # that would mean, we'd need to sort the filter conditions by table and alter the `list_of_tables` accordingly
-  #
-  # this test depends on the answer to the above issue:
-  # map(
-  #   dm_for_flatten_src[setdiff(names(dm_for_flatten_src), "sqlite")],
-  #   ~ expect_equivalent(
-  #     cdm_flatten_to_tbl(cdm_filter(.x, fact, something > 4), fact, dim_1, join = right_join) %>% collect(),
-  #     right_join(filter(fact, something > 4), dim_1, by = c("dim_1_key" = "dim_1_pk")) %>%
-  #       rename(fact.something = something.x, dim_1.something = something.y)
-  #   )
-  # )
+  map(
+    # sqlite: RIGHT and FULL OUTER JOINs are not currently supported
+    # yet, here we eventually use `left_join()` anyway
+    dm_for_flatten_src,
+    ~ expect_equivalent(
+      cdm_flatten_to_tbl(cdm_filter(.x, fact, something > 4), fact, dim_1, join = right_join) %>% collect(),
+      left_join(filter(fact, something > 4), dim_1, by = c("dim_1_key" = "dim_1_pk")) %>%
+        rename(fact.something = something.x, dim_1.something = something.y)
+    )
+  )
+
+  map(
+    # sqlite: RIGHT and FULL OUTER JOINs are not currently supported
+    # yet, here we eventually use `left_join()` anyway
+    dm_for_flatten_src,
+    ~ expect_equivalent(
+      cdm_flatten_to_tbl(cdm_filter(.x, fact, something > 4), fact, join = right_join) %>% collect(),
+      left_join(filter(fact, something > 4), dim_1, by = c("dim_1_key" = "dim_1_pk")) %>%
+        rename(fact.something = something.x, dim_1.something = something.y) %>%
+        left_join(rename(dim_2, dim_2.something = something), by = c("dim_2_key" = "dim_2_pk")) %>%
+        left_join(rename(dim_3, dim_3.something = something), by = c("dim_3_key" = "dim_3_pk")) %>%
+        left_join(rename(dim_4, dim_4.something = something), by = c("dim_4_key" = "dim_4_pk"))
+    )
+  )
+
+
+})
 
   test_that("`cdm_flatten_to_tbl()` does the right thing for 'anti_join()' and `semi_join()`", {
 
@@ -71,9 +84,9 @@ test_that("`cdm_flatten_to_tbl()` does the right thing for 'right_join()'", {
         cdm_nycflights13(cycle = TRUE) %>%
           cdm_rm_fk(flights, origin, airports),
         flights, join = semi_join),
-      semi_join(rename(flights, flights.year = year), rename(airlines, airlines.name = name), by = "carrier") %>%
-        semi_join(rename(airports, airports.name = name), by = c("dest" = "faa")) %>%
-        semi_join(rename(planes, planes.year = year), by = "tailnum")
+      semi_join(flights, airlines, by = "carrier") %>%
+        semi_join(airports, by = c("dest" = "faa")) %>%
+        semi_join(planes, by = "tailnum")
     )
 
     expect_equivalent(
@@ -85,4 +98,4 @@ test_that("`cdm_flatten_to_tbl()` does the right thing for 'right_join()'", {
     )
 
   })
-})
+

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -6,6 +6,17 @@ test_that("`cdm_flatten_to_tbl()` does the right thing", {
       result_from_flatten
     )
   )
+
+  map(
+    dm_for_flatten_src,
+    ~ expect_equivalent(
+      cdm_flatten_to_tbl(., fact, dim_1, dim_2) %>% collect(),
+      left_join(
+        rename(fact, fact.something = something), rename(dim_1, dim_1.something = something),
+        by = c("dim_1_key" = "dim_1_pk")) %>%
+        left_join(rename(dim_2, dim_2.something = something), by = c("dim_2_key" = "dim_2_pk"))
+    )
+  )
 })
 
 test_that("`cdm_flatten_to_tbl()` does the right thing for a one-table-dm", {
@@ -16,4 +27,61 @@ test_that("`cdm_flatten_to_tbl()` does the right thing for a one-table-dm", {
       fact
     )
   )
+})
+
+test_that("`cdm_flatten_to_tbl()` does the right thing for 'right_join()'", {
+  map(
+    # sqlite: RIGHT and FULL OUTER JOINs are not currently supported
+    dm_for_flatten_src[setdiff(names(dm_for_flatten_src), "sqlite")],
+    ~ expect_equivalent(
+      cdm_flatten_to_tbl(cdm_filter(.x, dim_1, dim_1_pk > 4), fact, dim_1, join = right_join) %>% collect(),
+      right_join(fact, filter(dim_1, dim_1_pk > 4), by = c("dim_1_key" = "dim_1_pk")) %>%
+        rename(fact.something = something.x, dim_1.something = something.y)
+    )
+  )
+
+  # It might be expected, that if the user choses a `right_join()`, `full_join()`, `semi_join()` or
+  # `anti_join()`, he expects only the direct effect of filter conditions on dimension tables
+  # to take an effect (so `dim_1, dim_1_pk > 4` has only an effect on table `dim_1` and no cascading effect);
+  # that would mean, we'd need to sort the filter conditions by table and alter the `list_of_tables` accordingly
+  #
+  # this test depends on the answer to the above issue:
+  # map(
+  #   dm_for_flatten_src[setdiff(names(dm_for_flatten_src), "sqlite")],
+  #   ~ expect_equivalent(
+  #     cdm_flatten_to_tbl(cdm_filter(.x, fact, something > 4), fact, dim_1, join = right_join) %>% collect(),
+  #     right_join(filter(fact, something > 4), dim_1, by = c("dim_1_key" = "dim_1_pk")) %>%
+  #       rename(fact.something = something.x, dim_1.something = something.y)
+  #   )
+  # )
+
+  test_that("`cdm_flatten_to_tbl()` does the right thing for 'anti_join()' and `semi_join()`", {
+
+    expect_equivalent(
+      cdm_flatten_to_tbl(
+        cdm_nycflights13(cycle = TRUE) %>%
+          cdm_rm_fk(flights, origin, airports),
+        flights, airports, join = anti_join),
+        anti_join(flights, airports, by = c("dest" = "faa"))
+      )
+
+    expect_equivalent(
+      cdm_flatten_to_tbl(
+        cdm_nycflights13(cycle = TRUE) %>%
+          cdm_rm_fk(flights, origin, airports),
+        flights, join = semi_join),
+      semi_join(rename(flights, flights.year = year), rename(airlines, airlines.name = name), by = "carrier") %>%
+        semi_join(rename(airports, airports.name = name), by = c("dest" = "faa")) %>%
+        semi_join(rename(planes, planes.year = year), by = "tailnum")
+    )
+
+    expect_equivalent(
+      cdm_flatten_to_tbl(
+        cdm_nycflights13(cycle = TRUE) %>%
+          cdm_rm_fk(flights, origin, airports),
+        flights, airlines, join = semi_join),
+      semi_join(flights, airlines, by = "carrier")
+    )
+
+  })
 })


### PR DESCRIPTION
- minimized disambiguation (disambiguate after selecting relevant tables)
- ellipsis taking dimension tables as argument
- fact-table is for some joins the only table that is affected by filters

closes #62

One question remains for me: I could imagine, that a user who - in the example of `dm_for_flatten` - sets filters and then uses `cdm_flatten_to_tbl()`:
```r
cdm_filter(dm_for_flatten, dim_1, dim_1_pk > 6) %>% 
  cdm_filter(dim_2, dim_2_pk %in% letters[4:10]) %>% 
  cdm_flatten_to_tbl(fact, dim_1, dim_2, join = right_join)
```
might not want the filter on table `dim_1` to affect table `dim_2` and vice versa. One could think of having the filters just affect the respective tables in `ordered_table_list` and not have a cascading effect.

another thing is, that the order of the tables in the `dm` affects the outcome of `cdm_flatten_to_tbl()` with `join = right_join`. So far I addressed this with a warning. Is this enough?