### PR TITLE
remove src from `dm` since implicitly available

### DIFF
--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -77,7 +77,6 @@ cdm_copy_to <- nse_function(c(dest, dm, ...,
   new_src <- src_from_src_or_con(dest)
 
   remote_dm <- new_dm2(
-    src = new_src,
     tables = new_tables,
     base_dm = dm
   )

--- a/R/dm.R
+++ b/R/dm.R
@@ -282,7 +282,7 @@ as_dm.default <- function(x) {
 
 tbl_src <- function(x) {
   if (is.data.frame(x)) {
-    "local"
+    NULL
   } else if (inherits(x, "tbl_sql")) {
     x$src
   } else {
@@ -304,8 +304,10 @@ format.dm <- function(x, ...) {
 #' @import cli
 print.dm <- function(x, ...) {
   cat_rule("Table source", col = "green")
+  src <- cdm_get_src(x)
+  if (is_null(src)) src <- "local"
 
-  db_info <- strsplit(format(cdm_get_src(x)), "\n")[[1]][[1]]
+  db_info <- strsplit(format(src), "\n")[[1]][[1]]
 
   cat_line(db_info)
 

--- a/R/dm.R
+++ b/R/dm.R
@@ -492,5 +492,5 @@ cdm_reset_all_filters <- function(dm) {
 all_same_source <- function(tables) {
   # Use `NULL` if `tables` is empty
   first_table <- tables[1][[1]]
-  is.null(detect(tables[-1], ~ same_src(., first_table)))
+  is.null(detect(tables[-1], ~ !same_src(., first_table)))
 }

--- a/R/dm.R
+++ b/R/dm.R
@@ -148,8 +148,7 @@ validate_dm <- function(x) {
 #' @export
 cdm_get_src <- function(x) {
   tables <- cdm_get_tables(x)
-  if (!all_same_source(tables)) abort_not_same_src()
-  tbl_src(tables[[1]])
+  if (!is_empty(tables)) tbl_src(tables[[1]]) else default_local_src()
 }
 
 #' Get tables component
@@ -280,7 +279,7 @@ as_dm.default <- function(x) {
 }
 
 tbl_src <- function(x) {
-  if (is.data.frame(x)) {
+  if (is_empty(x) || is.data.frame(x)) {
     default_local_src()
   } else if (inherits(x, "tbl_sql")) {
     x$src

--- a/R/dm.R
+++ b/R/dm.R
@@ -99,8 +99,8 @@ new_dm2 <- function(tables = cdm_get_tables(base_dm),
                     fks = cdm_get_data_model_fks(base_dm),
                     filter = cdm_get_filter(base_dm),
                     base_dm) {
-  if (!all_same_source(tables)) abort_not_same_src()
   stopifnot(!is.null(tables))
+  if (!all_same_source(tables)) abort_not_same_src()
   stopifnot(!is.null(data_model_tables))
   stopifnot(!is.null(pks))
   stopifnot(!is.null(fks))

--- a/R/dm.R
+++ b/R/dm.R
@@ -490,5 +490,7 @@ cdm_reset_all_filters <- function(dm) {
 }
 
 all_same_source <- function(tables) {
-  all(map_lgl(tables, same_src, tables[[1]]))
+  # Use `NULL` if `tables` is empty
+  first_table <- tables[1][[1]]
+  is.null(detect(tables[-1], ~ same_src(., first_table)))
 }

--- a/R/dm.R
+++ b/R/dm.R
@@ -99,9 +99,7 @@ new_dm2 <- function(tables = cdm_get_tables(base_dm),
                     fks = cdm_get_data_model_fks(base_dm),
                     filter = cdm_get_filter(base_dm),
                     base_dm) {
-  if (!all_same_source(tables)) abort_not_same_src()
   stopifnot(!is.null(tables))
-  if (!all_same_source(tables)) abort_not_same_src()
   stopifnot(!is.null(data_model_tables))
   stopifnot(!is.null(pks))
   stopifnot(!is.null(fks))
@@ -482,13 +480,6 @@ cdm_rename_tbl <- function(dm, ...) {
     new_table_names,
     rename_table_of_dm,
     .init = dm
-  )
-}
-
-cdm_reset_all_filters <- function(dm) {
-  new_dm2(
-    filter = tibble(table = character(0), filter = list(0)),
-    base_dm = dm
   )
 }
 

--- a/R/dm.R
+++ b/R/dm.R
@@ -99,6 +99,7 @@ new_dm2 <- function(tables = cdm_get_tables(base_dm),
                     fks = cdm_get_data_model_fks(base_dm),
                     filter = cdm_get_filter(base_dm),
                     base_dm) {
+  if (!all_same_source(tables)) abort_not_same_src()
   stopifnot(!is.null(tables))
   if (!all_same_source(tables)) abort_not_same_src()
   stopifnot(!is.null(data_model_tables))

--- a/R/dm.R
+++ b/R/dm.R
@@ -53,7 +53,7 @@ dm <- nse_function(c(src, data_model = NULL), ~ {
   table_names <- set_names(data_model$tables$table)
   tables <- map(table_names, tbl, src = src)
 
-  new_dm(src, tables, data_model)
+  new_dm(tables, data_model)
 })
 
 #' Low-level constructor
@@ -63,10 +63,9 @@ dm <- nse_function(c(src, data_model = NULL), ~ {
 #'
 #' @rdname dm
 #' @export
-new_dm <- function(src, tables, data_model) {
-  if (!is.src(src) && !is(src, "DBIConnection")) abort_no_src_or_con()
+new_dm <- function(tables, data_model) {
+  if (!all_same_source(tables)) abort_not_same_src()
   stopifnot(datamodelr::is.data_model(data_model))
-  src <- src_from_src_or_con(src)
 
   columns <- as_tibble(data_model$columns)
 
@@ -91,26 +90,24 @@ new_dm <- function(src, tables, data_model) {
       as_tibble()
   }
 
-  new_dm2(src, tables, data_model_tables, keys, references, filter = NULL)
+  new_dm2(tables, data_model_tables, keys, references, filter = NULL)
 }
 
-new_dm2 <- function(src = cdm_get_src(base_dm),
-                    tables = cdm_get_tables(base_dm),
+new_dm2 <- function(tables = cdm_get_tables(base_dm),
                     data_model_tables = cdm_get_data_model_tables(base_dm),
                     pks = cdm_get_data_model_pks(base_dm),
                     fks = cdm_get_data_model_fks(base_dm),
                     filter = cdm_get_filter(base_dm),
                     base_dm) {
-
-  stopifnot(!is.null(src))
+  if (!all_same_source(tables)) abort_not_same_src()
   stopifnot(!is.null(tables))
   stopifnot(!is.null(data_model_tables))
   stopifnot(!is.null(pks))
   stopifnot(!is.null(fks))
 
+
   structure(
     list(
-      src = src,
       tables = tables,
       data_model_tables = data_model_tables,
       data_model_pks = pks,
@@ -151,7 +148,9 @@ validate_dm <- function(x) {
 #'
 #' @export
 cdm_get_src <- function(x) {
-  unclass(x)$src
+  tables <- cdm_get_tables(x)
+  if (!all_same_source(tables)) abort_not_same_src()
+  tbl_src(tables[[1]])
 }
 
 #' Get tables component
@@ -270,29 +269,24 @@ as_dm.default <- function(x) {
   # Automatic name repair
   names(x) <- vctrs::vec_as_names(names2(x), repair = "unique")
 
-  src <- tbl_src(x[[1]])
-
-  # FIXME: Check if all sources identical
+  # Check if all sources are identical
+  if (!all_same_source(x)) abort_not_same_src()
 
   # Empty tibbles as proxy, we don't need to know the columns
   # and we don't have keys yet
   proxies <- map(x, ~ tibble(a = 0))
   data_model <- datamodelr::dm_from_data_frames(proxies)
 
-  new_dm(src, x, data_model)
+  new_dm(x, data_model)
 }
 
 tbl_src <- function(x) {
   if (is.data.frame(x)) {
-    src_df(env = new_environment(x))
+    "local"
   } else if (inherits(x, "tbl_sql")) {
     x$src
   } else {
-    # FIXME: Classed error code
-    stop(
-      "Don't know how to determine table source for object of class ",
-      class(x)[[1]]
-    )
+    abort_what_a_weird_object(class(x)[[1]])
   }
 }
 
@@ -439,11 +433,7 @@ collect.dm <- function(x, ...) {
   list_of_rem_tbls <- cdm_apply_filters(x) %>% cdm_get_tables()
   tables <- map(list_of_rem_tbls, collect)
 
-  # FIXME: in future src will no longer be part of `dm` object.
-  # https://github.com/krlmlr/dm/issues/38
-  # `cdm_get_src(x)` needs to be removed (is wrong anyway)
   new_dm(
-    cdm_get_src(x),
     tables,
     cdm_get_data_model(x)
   )
@@ -461,7 +451,6 @@ rename_table_of_dm <- function(dm, old_name, new_name) {
   new_tables <- set_names(tables, table_names)
 
   new_dm(
-    src = cdm_get_src(dm),
     tables = new_tables,
     data_model = datamodel_rename_table(
       cdm_get_data_model(dm), old_name_q, new_name_q
@@ -499,4 +488,8 @@ cdm_reset_all_filters <- function(dm) {
     filter = tibble(table = character(0), filter = list(0)),
     base_dm = dm
   )
+}
+
+all_same_source <- function(tables) {
+  all(map_lgl(tables, same_src, tables[[1]]))
 }

--- a/R/dm.R
+++ b/R/dm.R
@@ -283,7 +283,7 @@ as_dm.default <- function(x) {
 
 tbl_src <- function(x) {
   if (is.data.frame(x)) {
-    NULL
+    default_local_src()
   } else if (inherits(x, "tbl_sql")) {
     x$src
   } else {
@@ -306,7 +306,6 @@ format.dm <- function(x, ...) {
 print.dm <- function(x, ...) {
   cat_rule("Table source", col = "green")
   src <- cdm_get_src(x)
-  if (is_null(src)) src <- "local"
 
   db_info <- strsplit(format(src), "\n")[[1]][[1]]
 

--- a/R/dm.R
+++ b/R/dm.R
@@ -492,6 +492,13 @@ cdm_reset_all_filters <- function(dm) {
   )
 }
 
+cdm_reset_all_filters <- function(dm) {
+  new_dm2(
+    filter = tibble(table = character(0), filter = list(0)),
+    base_dm = dm
+  )
+}
+
 all_same_source <- function(tables) {
   all(map_lgl(tables, same_src, tables[[1]]))
 }

--- a/R/dm.R
+++ b/R/dm.R
@@ -148,7 +148,7 @@ validate_dm <- function(x) {
 #' @export
 cdm_get_src <- function(x) {
   tables <- cdm_get_tables(x)
-  if (!is_empty(tables)) tbl_src(tables[[1]]) else default_local_src()
+  tbl_src(tables[1][[1]])
 }
 
 #' Get tables component

--- a/R/draw-dm.R
+++ b/R/draw-dm.R
@@ -78,7 +78,6 @@ cdm_set_colors <- function(dm, ...) {
   display <- color_quos_to_display(...)
 
   new_dm(
-    cdm_get_src(dm),
     cdm_get_tables(dm),
     dm_set_display(data_model, display)
   )

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -431,3 +431,25 @@ error_semi_anti_nys <- function() {
   paste0("When flattening a `dm` with `semi_join()` or `anti_join()` all tables have to be ",
   "directly connected to table `start` (at least currently).")
 }
+
+# not all tables have the same src ----------------------------------------
+
+
+abort_not_same_src <- function() {
+  abort(error_not_same_src(), .subclass = cdm_error_full("not_same_src"))
+}
+
+error_not_same_src <- function() {
+  "Not all tables in the object share the same `src`"
+}
+
+# Something other than tables are put in a `dm` ------------------
+
+abort_what_a_weird_object <- function(class) {
+  abort(error_what_a_weird_object(class), .subclass = cdm_error_full("what_a_weird_object"))
+}
+
+error_what_a_weird_object <- function(class) {
+  paste0("Don't know how to determine table source for object of class ",
+         class)
+}

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -409,3 +409,14 @@ error_what_a_weird_object <- function(class) {
   paste0("Don't know how to determine table source for object of class ",
          class)
 }
+
+# `right_join()` might produce random result for `cdm_flatten_to_tbl()`
+
+abort_rj_not_wd <- function() {
+  abort(error_rj_not_wd(), .subclass = cdm_error_full("_rj_not_wd"))
+}
+
+error_rj_not_wd <- function() {
+  paste0("No well-defined result, when using `cdm_flatten_to_tbl()` with `right_join()` ",
+         "with more than 2 tables involved (depends on order of tables in `dm`)")
+}

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -387,3 +387,25 @@ error_semi_anti_nys <- function() {
   paste0("When flattening a `dm` with `semi_join()` or `anti_join()` all tables have to be ",
   "directly connected to table `start`.")
 }
+
+# not all tables have the same src ----------------------------------------
+
+
+abort_not_same_src <- function() {
+  abort(error_not_same_src(), .subclass = cdm_error_full("not_same_src"))
+}
+
+error_not_same_src <- function() {
+  "Not all tables in the object share the same `src`"
+}
+
+# Something other than tables are put in a `dm` ------------------
+
+abort_what_a_weird_object <- function(class) {
+  abort(error_what_a_weird_object(class), .subclass = cdm_error_full("what_a_weird_object"))
+}
+
+error_what_a_weird_object <- function(class) {
+  paste0("Don't know how to determine table source for object of class ",
+         class)
+}

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -413,10 +413,21 @@ error_what_a_weird_object <- function(class) {
 # `right_join()` might produce random result for `cdm_flatten_to_tbl()`
 
 abort_rj_not_wd <- function() {
-  abort(error_rj_not_wd(), .subclass = cdm_error_full("_rj_not_wd"))
+  abort(error_rj_not_wd(), .subclass = cdm_error_full("rj_not_wd"))
 }
 
 error_rj_not_wd <- function() {
   paste0("No well-defined result, when using `cdm_flatten_to_tbl()` with `right_join()` ",
          "with more than 2 tables involved (depends on order of tables in `dm`)")
+}
+
+# `semi_join()` and `anti_join()` not supported for `cdm_flatten_to_tbl()` for deep hierarchy
+
+abort_semi_anti_nys <- function() {
+  abort(error_semi_anti_nys(), .subclass = cdm_error_full("semi_anti_nys"))
+}
+
+error_semi_anti_nys <- function() {
+  paste0("When flattening a `dm` with `semi_join()` or `anti_join()` all tables have to be ",
+  "directly connected to table `start` (at least currently).")
 }

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -42,7 +42,7 @@ cdm_add_fk_impl <- function(dm, table, column, ref_table, ref_column) {
 
   new_data_model <- upd_data_model_reference(cdm_data_model, table, column, ref_table, ref_column)
 
-  new_dm(cdm_get_src(dm), cdm_get_tables(dm), new_data_model)
+  new_dm(cdm_get_tables(dm), new_data_model)
 }
 
 #' Does a reference from one table of a `dm` to another exist?
@@ -140,7 +140,6 @@ cdm_rm_fk <- function(dm, table, column, ref_table) {
   }
 
   new_dm(
-    cdm_get_src(dm),
     cdm_get_tables(dm),
     rm_data_model_reference(
       cdm_get_data_model(dm),

--- a/R/learn_dm_from_db.R
+++ b/R/learn_dm_from_db.R
@@ -33,7 +33,6 @@ cdm_learn_from_db <- function(dest) {
     pull()
 
   new_dm(
-    src = src,
     tables = map(table_names, ~ tbl(con, .)) %>% set_names(table_names),
     data_model = get_datamodel_from_overview(overview)
   )

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -67,7 +67,7 @@ cdm_add_pk_impl <- function(dm, table, column) {
   new_data_model <- cdm_get_data_model(dm) %>%
     datamodelr::dm_set_key(table, column)
 
-  new_dm(cdm_get_src(dm), cdm_get_tables(dm), new_data_model)
+  new_dm(cdm_get_tables(dm), new_data_model)
 }
 
 #' Does a table of a [`dm`] object have a column set as primary key?

--- a/R/select_tables_from_dm.R
+++ b/R/select_tables_from_dm.R
@@ -23,7 +23,6 @@ cdm_select_tbl <- function(dm, ...) {
   table_objs <- map(set_names(old_table_names), ~ tbl(dm, .))
 
   new_dm(
-    src = cdm_get_src(dm),
     tables = table_objs,
     data_model = new_data_model
   ) %>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,3 +14,7 @@ commas <- function(x) {
 tick <- function(x) {
   paste0("`", x, "`")
 }
+
+default_local_src <- function() {
+  src_df(env = .GlobalEnv)
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -260,7 +260,7 @@ Further resources:
 - [Class 'dm' and basic operations](https://krlmlr.github.io/dm/articles/dm-class-and-basic-operations.html) article
 - [Visualizing 'dm' objects](https://krlmlr.github.io/dm/articles/dm-visualization.html) article
 - [Low-level operations](https://krlmlr.github.io/dm/articles/dm-low-level.html) article
-<!-- FIXME: vignettes missing; once there, needs to be linked -->
+<!-- FIXME: vignettes missing;  once there, needs to be linked -->
 
 ## Standing on the shoulders of giants
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,12 @@ This can result in long and inflated pipe chains full of `left_join()`,
 `anti_join()` and other forms of merging data.
 
 {dm} offers a more elegant and shorter way to combine values by
-establishing key relations (see next section) while augmenting
-{dplyr}/{dbplyr} workflows.
+establishing key relations (see next section [Good to
+Know](#good-to-know)) while augmenting {dplyr}/{dbplyr} workflows.
+
+You can have the best of both worlds: Manage your data with {dm} as
+linked tables, then flatten multiple tables into one for your analysis
+with {dplyr} on an as-needed basis.
 
 ## Good to Know
 
@@ -241,7 +245,7 @@ cdm_nycflights13()
 ```
 
 <PRE class="fansi fansi-output"><CODE>#&gt; <span style='color: #00BB00;'>──</span><span> </span><span style='color: #00BB00;'>Table source</span><span> </span><span style='color: #00BB00;'>───────────────────────────────────────────────────────────</span><span>
-#&gt; src:  &lt;package: nycflights13&gt;
+#&gt; local
 #&gt; </span><span style='color: #555555;'>──</span><span> </span><span style='color: #555555;'>Data model</span><span> </span><span style='color: #555555;'>─────────────────────────────────────────────────────────────</span><span>
 #&gt; Data model object:
 #&gt;   5 tables:  airlines, airports, flights, planes ... 
@@ -380,7 +384,7 @@ to start. Further resources:
   - [Low-level
     operations](https://krlmlr.github.io/dm/articles/dm-low-level.html)
     article
-    <!-- FIXME: vignettes missing; once there, needs to be linked -->
+    <!-- FIXME: vignettes missing;  once there, needs to be linked -->
 
 ## Standing on the shoulders of giants
 

--- a/man/dm.Rd
+++ b/man/dm.Rd
@@ -14,7 +14,7 @@
 \usage{
 dm(src, data_model = NULL)
 
-new_dm(src, tables, data_model)
+new_dm(tables, data_model)
 
 validate_dm(x)
 

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -15,7 +15,6 @@ test_that("cdm_select_tbl() selects a part of a larger `dm` as a reduced `dm`?",
     ~ expect_equal(
       cdm_select_tbl(.x, t1, t6),
       new_dm(
-        src = cdm_get_src(.x),
         tables = list("t1" = tbl(.x, "t1"), "t6" = tbl(.x, "t6")),
         data_model = cdm_get_data_model(.x) %>%
           rm_table_from_data_model(c("t2", "t3", "t4", "t5"))
@@ -28,7 +27,6 @@ test_that("cdm_select_tbl() selects a part of a larger `dm` as a reduced `dm`?",
     ~ expect_equal(
       cdm_select_tbl(.x, t1_new = t1, t6_new = t6),
       new_dm(
-        src = cdm_get_src(.x),
         tables = list("t1_new" = tbl(.x, "t1"), "t6_new" = tbl(.x, "t6")),
         data_model = cdm_get_data_model(.x) %>%
           rm_table_from_data_model(c("t2", "t3", "t4", "t5")) %>%

--- a/vignettes/dm-class-and-basic-operations.Rmd
+++ b/vignettes/dm-class-and-basic-operations.Rmd
@@ -35,10 +35,11 @@ Let's first have a look at the new class:
 The `dm` class contains a set of tables as well as information about their primary keys and the relations between the tables. 
 You can have your `dm` object on different data sources, such as a local environment or a database.
 
-`dm` is a wrapper around the two `data_model` object
- from the package [{datamodelr}](https://github.com/bergant/datamodelr)
+`dm` is a wrapper around two classes, which are independent from each other:
 
-If the tables in the `dm` are on a database, the corresponding [`src` object](https://dplyr.tidyverse.org/reference/src.html) from {dplyr} is implicitly part of the `dm`
+1. part of the object is a [`src` object](https://dplyr.tidyverse.org/reference/src.html) from {dplyr}
+2. the other part is a class `data_model` object
+ from the package [{datamodelr}](https://github.com/bergant/datamodelr)
 
 The `src` object contains the information, where the tables of your data model are physically stored. 
 In the `data_model` object the meta-information is about your data is kept, among others:
@@ -46,7 +47,7 @@ In the `data_model` object the meta-information is about your data is kept, amon
 - what are the primary keys in your schema?
 - how are the tables related to each other, i.e. what are the foreign key relations?
 
-Last but not least, a third part of the object is a named list containing the tables on the `src` (or local ones).
+Last but not least, a third part of the object is a named list containing the tables on the `src`.
 
 So much to the theory, let's see how to construct such an object and how it looks in `R`:
 
@@ -75,12 +76,14 @@ iris_dm <- as_dm(list("iris1" = iris, "iris2" = iris))
 iris_dm
 ```
 
-And lastly, with `new_dm()` you can create a `dm` by providing the two necessary part for its creation:
+And lastly, with `new_dm()` you can create a `dm` by providing the three individual parts it consists of:
 ```{r}
+local_src <- src_df(env = new.env())
 tables <- list("iris1" = iris, "iris2" = iris)
 data_model <- cdm_get_data_model(iris_dm)
 another_iris_dm <- 
   new_dm(
+    src = local_src,
     tables = tables,
     data_model = data_model
     )
@@ -88,7 +91,7 @@ another_iris_dm
 ```
 
 You saw, that with `cdm_get_data_model()` we access the `data_model` part of a `dm`.
-Similarly, we can get the list of tables with `cdm_get_tables()` and the `src` object with `cdm_get_src()` (is `NULL` for local tables).
+Similarly, we can get the list of tables with `cdm_get_tables()` and the `src` object with `cdm_get_src()`.
 
 In order to pull a specific table from a `dm`, use:
 ```{r}

--- a/vignettes/dm-class-and-basic-operations.Rmd
+++ b/vignettes/dm-class-and-basic-operations.Rmd
@@ -83,7 +83,6 @@ tables <- list("iris1" = iris, "iris2" = iris)
 data_model <- cdm_get_data_model(iris_dm)
 another_iris_dm <- 
   new_dm(
-    src = local_src,
     tables = tables,
     data_model = data_model
     )

--- a/vignettes/dm-class-and-basic-operations.Rmd
+++ b/vignettes/dm-class-and-basic-operations.Rmd
@@ -35,11 +35,10 @@ Let's first have a look at the new class:
 The `dm` class contains a set of tables as well as information about their primary keys and the relations between the tables. 
 You can have your `dm` object on different data sources, such as a local environment or a database.
 
-`dm` is a wrapper around two classes, which are independent from each other:
-
-1. part of the object is a [`src` object](https://dplyr.tidyverse.org/reference/src.html) from {dplyr}
-2. the other part is a class `data_model` object
+`dm` is a wrapper around the two `data_model` object
  from the package [{datamodelr}](https://github.com/bergant/datamodelr)
+
+If the tables in the `dm` are on a database, the corresponding [`src` object](https://dplyr.tidyverse.org/reference/src.html) from {dplyr} is implicitly part of the `dm`
 
 The `src` object contains the information, where the tables of your data model are physically stored. 
 In the `data_model` object the meta-information is about your data is kept, among others:
@@ -47,7 +46,7 @@ In the `data_model` object the meta-information is about your data is kept, amon
 - what are the primary keys in your schema?
 - how are the tables related to each other, i.e. what are the foreign key relations?
 
-Last but not least, a third part of the object is a named list containing the tables on the `src`.
+Last but not least, a third part of the object is a named list containing the tables on the `src` (or local ones).
 
 So much to the theory, let's see how to construct such an object and how it looks in `R`:
 
@@ -76,14 +75,12 @@ iris_dm <- as_dm(list("iris1" = iris, "iris2" = iris))
 iris_dm
 ```
 
-And lastly, with `new_dm()` you can create a `dm` by providing the three individual parts it consists of:
+And lastly, with `new_dm()` you can create a `dm` by providing the two necessary part for its creation:
 ```{r}
-local_src <- src_df(env = new.env())
 tables <- list("iris1" = iris, "iris2" = iris)
 data_model <- cdm_get_data_model(iris_dm)
 another_iris_dm <- 
   new_dm(
-    src = local_src,
     tables = tables,
     data_model = data_model
     )
@@ -91,7 +88,7 @@ another_iris_dm
 ```
 
 You saw, that with `cdm_get_data_model()` we access the `data_model` part of a `dm`.
-Similarly, we can get the list of tables with `cdm_get_tables()` and the `src` object with `cdm_get_src()`.
+Similarly, we can get the list of tables with `cdm_get_tables()` and the `src` object with `cdm_get_src()` (is `NULL` for local tables).
 
 In order to pull a specific table from a `dm`, use:
 ```{r}

--- a/vignettes/dm.Rmd
+++ b/vignettes/dm.Rmd
@@ -83,7 +83,7 @@ cdm_get_src(flights_dm)
 
 
 ```{r}
-# Quering nrow() for each table, to suppress otherwise huge output
+# Querying nrow() for each table, to suppress otherwise huge output
 cdm_get_tables(flights_dm) %>% 
   map_int(nrow)
 ```

--- a/vignettes/dm.Rmd
+++ b/vignettes/dm.Rmd
@@ -83,7 +83,7 @@ cdm_get_src(flights_dm)
 
 
 ```{r}
-# Querying nrow() for each table, to suppress otherwise huge output
+# Quering nrow() for each table, to suppress otherwise huge output
 cdm_get_tables(flights_dm) %>% 
   map_int(nrow)
 ```


### PR DESCRIPTION
- remove `src` from `dm`
-  add some checks for same src of tables
- add 2 classed errors
- `cdm_get_src()` for local `dm` returns `.GlobalEnv`

closes #38 