### PR TITLE
treatment of `semi_`- and `anti_join()` in `cdm_flatten_to_tbl()`

### DIFF
--- a/R/flatten.R
+++ b/R/flatten.R
@@ -23,28 +23,39 @@
 #' The result is one table with unique column names.
 #' Use the `...` if you want to control which tables should be joined to table `start`.
 #'
-#' How does filtering affect the result?
+#' **How does filtering affect the result?**
 #'
-#' **Case 1**, either no filter conditions are set in the `dm`, or only in a part unconnected to
+#' *Case 1*, either no filter conditions are set in the `dm`, or only in a part unconnected to
 #' table `start`:
 #' The necessary disambiguations of the column names are performed first. Then all
 #' involved foreign tables are joined to table `start` successively with the join function given in
 #' parameter `join`.
 #'
-#' **Case 2**, filter conditions are set for at least one table connected to `start`:
+#' *Case 2*, filter conditions are set for at least one table connected to `start`:
 #' The result of filtering a `dm` object is necessarily a data model conforming to referential integrity.
 #' Consequently, there is no difference between `left_join`, `right_join`, `inner_join` and `full_join`.
 #' In this case, `left_join` is being used. Using `semi_join` in `cdm_flatten_to_tbl()` on a filtered `dm`
 #' is identical to `tbl(dm, start)`, and `anti_join` is identical to `tbl(dm, start) %>% filter(1 == 0)`.
 #' Disambiguation is performed initially if necessary.
 #'
+#' **join-methods: `join = semi_join()` and `join = anti_join()`**
+#'
+#' The implementation of this function for `semi_join` and `anti_join` is different from the other join-methods:
+#' 1. `dplyr::semi_join()` is successively used to determine which rows of table `start` contain valid lookup-values
+#' in the primary key columns of all its included parent tables.
+#' 2. For method `join = semi_join`, this is the result of the flattening. For method `join = anti_join`,
+#' `dplyr::anti_join()` is calculated between the original table and the result from 1., effectively letting
+#' those rows of table `start` remain, whose references are missing in at least one parent table.
+#'
+#' The result for `semi_join` lets you know which references are intact everywhere.
+#' The result from `anti_join` tells you, which references are missing somewhere.
+#'
+#' **join-method: `join = right_join()`**
+#'
 #' Mind, that calling `cdm_flatten_to_tbl()` on an unfiltered `dm` with `join = right_join` would not lead
 #' to a well-defined result, if two or more foreign tables are to be joined to `start`. The resulting
 #' table would depend on the order the tables are listed in the `dm`. Therefore trying this results
 #' in an error.
-#'
-#' Currently, it is not possible to use `semi_join` or `anti_join` as join-methods in the case of an
-#' unfiltered `dm`, when not all involved foreign tables are directly connected to table `start`.
 #'
 #' @return A wide table resulting of consecutively joining all tables involved to table `start`.
 #'

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -93,7 +93,7 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
   any_filter_in_conn_comp <- is_any_filter_conn_to_tbl(dm, start)
 
   if (any_filter_in_conn_comp) {
-    if (join_name == "semi_join") return(cdm_get_tables(dm)[[start]])
+    if (join_name == "semi_join") return(tbl(dm, start))
     if (join_name == "anti_join") return(cdm_get_tables(dm)[[start]] %>% filter(1 == 0))
     message("Using default `left_join()`, since filter conditions are set and `join` ",
             "neither `semi_join()` nor `anti_join()`.")

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -93,7 +93,7 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name) {
   any_filter_in_conn_comp <- is_any_filter_conn_to_tbl(dm, start)
 
   if (any_filter_in_conn_comp) {
-    if (join_name == "semi_join") return(tbl(dm, start))
+    if (join_name == "semi_join") return(cdm_get_tables(dm)[[start]])
     if (join_name == "anti_join") return(cdm_get_tables(dm)[[start]] %>% filter(1 == 0))
     message("Using default `left_join()`, since filter conditions are set and `join` ",
             "neither `semi_join()` nor `anti_join()`.")

--- a/man/cdm_flatten_to_tbl.Rd
+++ b/man/cdm_flatten_to_tbl.Rd
@@ -38,28 +38,41 @@ determine the parameter \code{by} for the necessary joins.
 The result is one table with unique column names.
 Use the \code{...} if you want to control which tables should be joined to table \code{start}.
 
-How does filtering affect the result?
+\strong{How does filtering affect the result?}
 
-\strong{Case 1}, either no filter conditions are set in the \code{dm}, or only in a part unconnected to
+\emph{Case 1}, either no filter conditions are set in the \code{dm}, or only in a part unconnected to
 table \code{start}:
 The necessary disambiguations of the column names are performed first. Then all
 involved foreign tables are joined to table \code{start} successively with the join function given in
 parameter \code{join}.
 
-\strong{Case 2}, filter conditions are set for at least one table connected to \code{start}:
+\emph{Case 2}, filter conditions are set for at least one table connected to \code{start}:
 The result of filtering a \code{dm} object is necessarily a data model conforming to referential integrity.
 Consequently, there is no difference between \code{left_join}, \code{right_join}, \code{inner_join} and \code{full_join}.
 In this case, \code{left_join} is being used. Using \code{semi_join} in \code{cdm_flatten_to_tbl()} on a filtered \code{dm}
 is identical to \code{tbl(dm, start)}, and \code{anti_join} is identical to \code{tbl(dm, start) \%>\% filter(1 == 0)}.
 Disambiguation is performed initially if necessary.
 
+\strong{join-methods: \code{join = semi_join()} and \code{join = anti_join()}}
+
+The implementation of this function for \code{semi_join} and \code{anti_join} is different from the other join-methods:
+\enumerate{
+\item \code{dplyr::semi_join()} is successively used to determine which rows of table \code{start} contain valid lookup-values
+in the primary key columns of all its included parent tables.
+\item For method \code{join = semi_join}, this is the result of the flattening. For method \code{join = anti_join},
+\code{dplyr::anti_join()} is calculated between the original table and the result from 1., effectively letting
+those rows of table \code{start} remain, whose references are missing in at least one parent table.
+}
+
+The result for \code{semi_join} lets you know which references are intact everywhere.
+The result from \code{anti_join} tells you, which references are missing somewhere.
+
+\strong{join-method: \code{join = right_join()}}
+
 Mind, that calling \code{cdm_flatten_to_tbl()} on an unfiltered \code{dm} with \code{join = right_join} would not lead
 to a well-defined result, if two or more foreign tables are to be joined to \code{start}. The resulting
 table would depend on the order the tables are listed in the \code{dm}. Therefore trying this results
 in an error.
-
-Currently, it is not possible to use \code{semi_join} or \code{anti_join} as join-methods in the case of an
-unfiltered \code{dm}, when not all involved foreign tables are directly connected to table \code{start}.
 }
 \examples{
 cdm_nycflights13() \%>\%

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -348,6 +348,21 @@ result_from_flatten <-
   left_join(dim_3_clean, by = c("dim_3_key" = "dim_3_pk")) %>%
   left_join(dim_4_clean, by = c("dim_4_key" = "dim_4_pk"))
 
+# another dm for flatten (no referential integrity)
+tbl_1 <- tibble(a = 1:5, b = 1:5, c = 1:5, d = 1:5)
+bad_dm <- as_dm(list(
+  tbl_1 = tbl_1, tbl_2 = tibble(e = 1:5, f = 1:5),
+  tbl_3 = tibble(g = 2:4, h = 2:4), tbl_4 = tibble(g = 1:6),
+  tbl_5 = tibble(h = 1:2))) %>% cdm_add_pk(tbl_1, a) %>% cdm_add_pk(tbl_2, e) %>%
+  cdm_add_pk(tbl_3, g) %>% cdm_add_pk(tbl_4, g) %>% cdm_add_pk(tbl_5, h) %>%
+  cdm_add_fk(tbl_1, b, tbl_2) %>% cdm_add_fk(tbl_1, c, tbl_4) %>%
+  cdm_add_fk(tbl_1, d, tbl_5) %>% cdm_add_fk(tbl_2, f, tbl_3)
+
+bad_dm2 <- as_dm(list(tbl_1 = tbl_1, tbl_2 = tibble(g = 2:4, h = 2:4), tbl_3 = tibble(h = 1:2))) %>%
+  cdm_add_pk(tbl_1, a) %>% cdm_add_pk(tbl_2, g) %>% cdm_add_pk(tbl_3, h) %>%
+  cdm_add_fk(tbl_1, b, tbl_2) %>% cdm_add_fk(tbl_1, c, tbl_3)
+
+
 # for database tests -------------------------------------------------
 
 # postgres needs to be cleaned of t?_2019_* tables for learn-test

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -97,6 +97,16 @@ test_that("`cdm_flatten_to_tbl()` does the right thing for 'right_join()'", {
       semi_join(flights, airlines, by = "carrier")
     )
 
+    expect_identical(cdm_flatten_to_tbl(bad_dm, tbl_1, join = semi_join), filter(tbl_1, a == 2))
+    expect_identical(cdm_flatten_to_tbl(bad_dm, tbl_1, join = anti_join), filter(tbl_1, a != 2))
+    expect_identical(cdm_flatten_to_tbl(bad_dm, tbl_1, tbl_2, tbl_3, join = semi_join),
+                     filter(tbl_1, a %in% 2:4))
+    expect_identical(cdm_flatten_to_tbl(bad_dm, tbl_1, tbl_2, tbl_3, join = anti_join),
+                         filter(tbl_1, !(a %in% 2:4)))
+    expect_identical(cdm_flatten_to_tbl(bad_dm2, tbl_1, join = semi_join),
+                     filter(tbl_1, a == 2))
+    expect_identical(cdm_flatten_to_tbl(bad_dm2, tbl_1, join = anti_join),
+                     filter(tbl_1, a != 2))
   })
 
 test_that("`cdm_flatten_to_tbl()` does the right thing for filtered `dm`s", {
@@ -127,13 +137,14 @@ test_that("`cdm_flatten_to_tbl()` does the right thing for filtered `dm`s", {
        )
   )
 
-  # this is NYI for anti_join and semi_join:
+  # semi_join with at least one table with distance > 1
   walk(dm_more_complex_src,
-       ~expect_error(
+       ~expect_identical(
          cdm_flatten_to_tbl(cdm_filter(., b, b_3 > 7), t5, join = semi_join) %>% collect(),
-         class = cdm_error("semi_anti_nys")
+         t5
        )
   )
+
 
 })
 


### PR DESCRIPTION
- in case of no filter in component, for the two join-methods the logic of `cdm_get_filtered_tables()` is used
- for `join = semi_join`, the result is the rows of `start` whose references are available in all parent tables
- for `join = anti_join` it's the opposite (`anti_join()` of original table with result of `semi_join()`); is basically those rows whose lookup-values that are missing at least once