### PR TITLE
New table_names argument to cdm_copy_to()

### DIFF
--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -61,14 +61,13 @@ cdm_copy_to <- nse_function(c(dest, dm, ...,
   }
 
   if (!is.null(table_names)) {
-    if (!is_false(unique_table_names)) {
-      # FIXME: Add error message
+    if (unique_table_names) {
       abort_unique_table_names_or_table_names()
     }
 
     not_found <- setdiff(names2(table_names), src_tbls(dm))
     if (has_length(not_found)) {
-      abort_table_not_found(unique(not_found))
+      abort_table_not_in_dm(unique(not_found))
     }
   }
 

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -70,7 +70,8 @@ cdm_copy_to <- nse_function(c(dest, dm, ...,
 
     not_found <- setdiff(names2(table_names), src_tbls(dm))
     if (has_length(not_found)) {
-      abort_table_not_in_dm(unique(not_found, src_tbls(dm)))
+      if (unique(not_found)[1] == "") abort_need_named_vec()
+      abort_table_not_in_dm(unique(not_found), src_tbls(dm))
     }
   }
 

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -13,6 +13,8 @@
 #'
 #' @param dest A `src` or `con` object like e.g. a database.
 #' @param dm A `dm` object.
+#' @param table_names The names on the `DB` you want the tables in the `dm` have
+#' after copying. The `dm` table names will remain unchanged.
 #' @param overwrite,types,indexes,unique_indexes Must remain `NULL`.
 #' @param set_key_constraints Boolean variable, if `TRUE` will mirror `dm` key constraints on a database.
 #' @param unique_table_names Boolean, if `FALSE` (default), original table names will be used, if `TRUE`,

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -13,8 +13,9 @@
 #'
 #' @param dest A `src` or `con` object like e.g. a database.
 #' @param dm A `dm` object.
-#' @param table_names The names on the `DB` you want the tables in the `dm` have
-#' after copying. The `dm` table names will remain unchanged.
+#' @param table_names A named character vector, containing the names you want the tables in the `dm` to have
+#' after copying them to the database. The table names within the `dm` will remain unchanged.
+#' The name of each element of the vector needs to be one of the table names of the `dm`.
 #' @param overwrite,types,indexes,unique_indexes Must remain `NULL`.
 #' @param set_key_constraints Boolean variable, if `TRUE` will mirror `dm` key constraints on a database.
 #' @param unique_table_names Boolean, if `FALSE` (default), original table names will be used, if `TRUE`,

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -71,7 +71,7 @@ cdm_copy_to <- nse_function(c(dest, dm, ...,
 
     not_found <- setdiff(names2(table_names), src_tbls(dm))
     if (has_length(not_found)) {
-      if (unique(not_found)[1] == "") abort_need_named_vec()
+      if (any(not_found == "")) abort_need_named_vec()
       abort_table_not_in_dm(unique(not_found), src_tbls(dm))
     }
   }
@@ -89,7 +89,6 @@ cdm_copy_to <- nse_function(c(dest, dm, ...,
     copy_data = copy_data,
     temporary = temporary,
     overwrite = FALSE,
-    table_names = table_names,
     ...
   )
 

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -16,6 +16,7 @@
 #' @param table_names A named character vector, containing the names you want the tables in the `dm` to have
 #' after copying them to the database. The table names within the `dm` will remain unchanged.
 #' The name of each element of the vector needs to be one of the table names of the `dm`.
+#' Those tables of the `dm` that are not addressed will be called by their original name on the database.
 #' @param overwrite,types,indexes,unique_indexes Must remain `NULL`.
 #' @param set_key_constraints Boolean variable, if `TRUE` will mirror `dm` key constraints on a database.
 #' @param unique_table_names Boolean, if `FALSE` (default), original table names will be used, if `TRUE`,

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -71,8 +71,8 @@ cdm_copy_to <- nse_function(c(dest, dm, ...,
 
     not_found <- setdiff(names2(table_names), src_tbls(dm))
     if (has_length(not_found)) {
-      if (any(not_found == "")) abort_need_named_vec()
-      abort_table_not_in_dm(unique(not_found), src_tbls(dm))
+      if (any(not_found == "")) abort_need_named_vec(dm)
+      abort_table_not_in_dm(unique(not_found), dm)
     }
   }
 

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -69,7 +69,7 @@ cdm_copy_to <- nse_function(c(dest, dm, ...,
 
     not_found <- setdiff(names2(table_names), src_tbls(dm))
     if (has_length(not_found)) {
-      abort_table_not_in_dm(unique(not_found))
+      abort_table_not_in_dm(unique(not_found, src_tbls(dm)))
     }
   }
 

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -53,14 +53,14 @@ abort_table_not_in_dm <- function(table_name, tables_in_dm) {
 }
 
 error_txt_table_not_in_dm <- function(table_name, tables_in_dm) {
-  if (table_name == "") {
+  if (table_name[[1]] == "") {
     "Table argument is missing."
   } else {
     paste0(
-      "Table: ",
-      table_name,
+      "Table", if_else(length(table_name) > 1, "s", ""), ": ",
+      commas(tick(table_name)),
       " not in `dm` object. Available table names are: ",
-      paste0(tables_in_dm, collapse = ", ")
+      commas(tick(tables_in_dm))
     )
   }
 }

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -305,6 +305,15 @@ error_txt_no_unique_indexes <- function() {
   paste0("`cdm_copy_to()` does not support the `unique_indexes` argument.")
 }
 
+abort_need_named_vec <- function() {
+  abort(error_txt_need_named_vec(), .subclass = cdm_error_full("need_named_vec"))
+}
+
+error_txt_need_named_vec <- function() {
+  paste0("Parameter `table_names` in `cdm_copy_to()` needs to be a named vector, the names ",
+  "being the original table names, as in `src_tbls(dm)`")
+}
+
 abort_src_not_db <- function() {
   abort(error_src_not_db(), .subclass = cdm_error_full("src_not_db"))
 }

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -450,3 +450,14 @@ error_what_a_weird_object <- function(class) {
   paste0("Don't know how to determine table source for object of class ",
          class)
 }
+
+
+# either explicit table names, or auto-unique ones ------------------------
+
+abort_unique_table_names_or_table_names <- function() {
+  abort(error_unique_table_names_or_table_names(), .subclass = cdm_error_full("unique_table_names_or_table_names"))
+}
+
+error_unique_table_names_or_table_names <- function() {
+  "Can't provide param `table_names` and have `unique_table_names = TRUE` at the same time."
+}

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -53,6 +53,7 @@ abort_table_not_in_dm <- function(table_name, tables_in_dm) {
 }
 
 error_txt_table_not_in_dm <- function(table_name, tables_in_dm) {
+  FIXME
   if (table_name[[1]] == "") {
     "Table argument is missing."
   } else {
@@ -311,7 +312,9 @@ abort_need_named_vec <- function() {
 
 error_txt_need_named_vec <- function() {
   paste0("Parameter `table_names` in `cdm_copy_to()` needs to be a named vector, the names ",
-  "being the original table names, as in `src_tbls(dm)`")
+    "must be from the original table names returned by `src_tbls()`: ",
+    commas(tick(src_tbls(dm)))
+  )
 }
 
 abort_src_not_db <- function() {
@@ -468,5 +471,5 @@ abort_unique_table_names_or_table_names <- function() {
 }
 
 error_unique_table_names_or_table_names <- function() {
-  "Can't provide param `table_names` and have `unique_table_names = TRUE` at the same time."
+  "Can supply either `table_names` or `unique_table_names = TRUE`, not both."
 }

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -48,22 +48,17 @@ error_txt_not_unique_key <- function(table_name, column_names) {
 # general error: table not part of `dm` -----------------------------------
 
 
-abort_table_not_in_dm <- function(table_name, tables_in_dm) {
-  abort(error_txt_table_not_in_dm(table_name, tables_in_dm), .subclass = cdm_error_full("table_not_in_dm"))
+abort_table_not_in_dm <- function(table_name, dm) {
+  abort(error_txt_table_not_in_dm(table_name, dm), .subclass = cdm_error_full("table_not_in_dm"))
 }
 
-error_txt_table_not_in_dm <- function(table_name, tables_in_dm) {
-  FIXME
-  if (table_name[[1]] == "") {
-    "Table argument is missing."
-  } else {
-    paste0(
-      "Table", if_else(length(table_name) > 1, "s", ""), ": ",
-      commas(tick(table_name)),
-      " not in `dm` object. Available table names are: ",
-      commas(tick(tables_in_dm))
-    )
-  }
+error_txt_table_not_in_dm <- function(table_name, dm) {
+  paste0(
+    "Tables ",
+    commas(tick(table_name)),
+    " not in `dm` object. Available table names: ",
+    commas(tick(src_tbls(dm)))
+  )
 }
 
 
@@ -306,11 +301,11 @@ error_txt_no_unique_indexes <- function() {
   paste0("`cdm_copy_to()` does not support the `unique_indexes` argument.")
 }
 
-abort_need_named_vec <- function() {
-  abort(error_txt_need_named_vec(), .subclass = cdm_error_full("need_named_vec"))
+abort_need_named_vec <- function(dm) {
+  abort(error_txt_need_named_vec(dm), .subclass = cdm_error_full("need_named_vec"))
 }
 
-error_txt_need_named_vec <- function() {
+error_txt_need_named_vec <- function(dm) {
   paste0("Parameter `table_names` in `cdm_copy_to()` needs to be a named vector, the names ",
     "must be from the original table names returned by `src_tbls()`: ",
     commas(tick(src_tbls(dm)))

--- a/R/test-dm.R
+++ b/R/test-dm.R
@@ -28,7 +28,9 @@ check_correct_input <- function(dm, table) {
     abort("`table` must be a string.")
   }
   cdm_table_names <- src_tbls(dm)
-  if (!table %in% cdm_table_names) abort_table_not_in_dm(table, cdm_table_names)
+  if (!table %in% cdm_table_names) {
+    abort_table_not_in_dm(table, dm)
+  }
 }
 
 # validates, that the given column is indeed part of the table of the `dm` object.

--- a/man/cdm_copy_to.Rd
+++ b/man/cdm_copy_to.Rd
@@ -24,7 +24,8 @@ unique table names will be created based on the original table names.}
 
 \item{table_names}{A named character vector, containing the names you want the tables in the \code{dm} to have
 after copying them to the database. The table names within the \code{dm} will remain unchanged.
-The name of each element of the vector needs to be one of the table names of the \code{dm}.}
+The name of each element of the vector needs to be one of the table names of the \code{dm}.
+Those tables of the \code{dm} that are not addressed will be called by their original name on the database.}
 
 \item{temporary}{Boolean variable, if \code{TRUE} will only create temporary tables, which will vanish when connection is interrupted.}
 }

--- a/man/cdm_copy_to.Rd
+++ b/man/cdm_copy_to.Rd
@@ -22,8 +22,9 @@ cdm_copy_to(dest, dm, ..., types = NULL, overwrite = NULL,
 \item{unique_table_names}{Boolean, if \code{FALSE} (default), original table names will be used, if \code{TRUE},
 unique table names will be created based on the original table names.}
 
-\item{table_names}{The names on the \code{DB} you want the tables in the \code{dm} have
-after copying. The \code{dm} table names will remain unchanged.}
+\item{table_names}{A named character vector, containing the names you want the tables in the \code{dm} to have
+after copying them to the database. The table names within the \code{dm} will remain unchanged.
+The name of each element of the vector needs to be one of the table names of the \code{dm}.}
 
 \item{temporary}{Boolean variable, if \code{TRUE} will only create temporary tables, which will vanish when connection is interrupted.}
 }

--- a/man/cdm_copy_to.Rd
+++ b/man/cdm_copy_to.Rd
@@ -6,7 +6,7 @@
 \usage{
 cdm_copy_to(dest, dm, ..., types = NULL, overwrite = NULL,
   indexes = NULL, unique_indexes = NULL, set_key_constraints = TRUE,
-  unique_table_names = FALSE, temporary = TRUE)
+  unique_table_names = FALSE, table_names = NULL, temporary = TRUE)
 }
 \arguments{
 \item{dest}{A \code{src} or \code{con} object like e.g. a database.}
@@ -21,6 +21,9 @@ cdm_copy_to(dest, dm, ..., types = NULL, overwrite = NULL,
 
 \item{unique_table_names}{Boolean, if \code{FALSE} (default), original table names will be used, if \code{TRUE},
 unique table names will be created based on the original table names.}
+
+\item{table_names}{The names on the \code{DB} you want the tables in the \code{dm} have
+after copying. The \code{dm} table names will remain unchanged.}
 
 \item{temporary}{Boolean variable, if \code{TRUE} will only create temporary tables, which will vanish when connection is interrupted.}
 }

--- a/tests/testthat/test-filter-dm.R
+++ b/tests/testthat/test-filter-dm.R
@@ -116,8 +116,7 @@ test_that("cdm_filter() fails when no table name is provided", {
     dm_for_filter_src,
     ~ expect_error(
       cdm_filter(.x),
-      class = cdm_error("table_not_in_dm"),
-      error_txt_table_not_in_dm("")
+      class = cdm_error("table_not_in_dm")
     )
   )
 })


### PR DESCRIPTION
@TSchiefer: Can you please pick up from here?

- Document argument, note that all table names are quoted with `dbplyr::ident_q()`
- Add tests