### PR TITLE
repair behaviour for named character vector as param for 'check_key()'

### DIFF
--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -450,3 +450,12 @@ error_what_a_weird_object <- function(class) {
   paste0("Don't know how to determine table source for object of class ",
          class)
 }
+
+abort_rename_plz <- function() {
+ abort(error_rename_plz(), .subclass = cdm_error_full("rename_plz"))
+}
+
+error_rename_plz <- function() {
+  paste0("`check_key()` can currently not deal with cases, when both variables `n` and `nn` are involved. ",
+  "Please consider changing one of the variables names.")
+}

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -450,12 +450,3 @@ error_what_a_weird_object <- function(class) {
   paste0("Don't know how to determine table source for object of class ",
          class)
 }
-
-abort_rename_plz <- function() {
- abort(error_rename_plz(), .subclass = cdm_error_full("rename_plz"))
-}
-
-error_rename_plz <- function() {
-  paste0("`check_key()` can currently not deal with cases, when both variables `n` and `nn` are involved. ",
-  "Please consider changing one of the variables names.")
-}

--- a/R/key-helpers.R
+++ b/R/key-helpers.R
@@ -27,6 +27,7 @@ check_key <- function(.data, ...) {
   data_q <- enquo(.data)
   .data <- eval_tidy(data_q)
   args <- exprs(...)
+  names(args) <- set_names(paste0("...", seq_along(args)))
   if (count_problem(args)) {
     count_col <- "nn"
   } else count_col <- "n"

--- a/R/key-helpers.R
+++ b/R/key-helpers.R
@@ -28,33 +28,16 @@ check_key <- function(.data, ...) {
   .data <- eval_tidy(data_q)
   args <- exprs(...)
   names(args) <- set_names(paste0("...", seq_along(args)))
-  if (count_problem(args)) {
-    count_col <- "nn"
-  } else count_col <- "n"
 
   duplicate_rows <-
     .data %>%
     as_tibble() %>% # as_tibble works only, if as_tibble.sf()-method is available
     count(!!!args) %>%
-    filter(!!sym(count_col) != 1)
+    filter(n != 1)
 
   if (nrow(duplicate_rows) != 0) abort_not_unique_key(as_label(data_q), map_chr(args, as_label))
 
   invisible(.data)
-}
-
-count_problem <- function(args) {
-  if (is_named(args)) {
-    names <- names(args)
-    if (any(names == "n") || any(as.character(args[names == ""]) == "n")) {
-      if (any(names == "nn") || any(as.character(args[names == ""]) == "nn")) abort_rename_plz()
-      return(TRUE)
-    }
-  } else if (any(as.character(args) == "n")) {
-    if (any(as.character(args) == "nn")) abort_rename_plz()
-    return(TRUE)
-  }
-  FALSE
 }
 
 # internal function to check if a column is a unique key of a table

--- a/R/key-helpers.R
+++ b/R/key-helpers.R
@@ -27,8 +27,9 @@ check_key <- function(.data, ...) {
   data_q <- enquo(.data)
   .data <- eval_tidy(data_q)
   args <- exprs(...)
-
-  if (any(!!args %in% "n")) count_col <- "nn" else count_col <- "n"
+  if (count_problem(args)) {
+    count_col <- "nn"
+  } else count_col <- "n"
 
   duplicate_rows <-
     .data %>%
@@ -39,6 +40,20 @@ check_key <- function(.data, ...) {
   if (nrow(duplicate_rows) != 0) abort_not_unique_key(as_label(data_q), map_chr(args, as_label))
 
   invisible(.data)
+}
+
+count_problem <- function(args) {
+  if (is_named(args)) {
+    names <- names(args)
+    if (any(names == "n") || any(as.character(args[names == ""]) == "n")) {
+      if (any(names == "nn") || any(as.character(args[names == ""]) == "nn")) abort_rename_plz()
+      return(TRUE)
+    }
+  } else if (any(as.character(args) == "n")) {
+    if (any(as.character(args) == "nn")) abort_rename_plz()
+    return(TRUE)
+  }
+  FALSE
 }
 
 # internal function to check if a column is a unique key of a table

--- a/tests/testthat/test-check-key.R
+++ b/tests/testthat/test-check-key.R
@@ -29,8 +29,7 @@ test_that("check_key() checks primary key properly?", {
     check_key(test_tbl, !!!c("n1" = sym("n"), "n2" = sym("nn")))
   )
 
-  expect_error(
-    check_key(test_tbl, !!!c(sym("n"), sym("nn"))),
-    class = cdm_error("rename_plz")
+  expect_silent(
+    check_key(test_tbl, !!!c(sym("n"), sym("nn")))
   )
 })

--- a/tests/testthat/test-check-key.R
+++ b/tests/testthat/test-check-key.R
@@ -23,4 +23,14 @@ test_that("check_key() checks primary key properly?", {
       check_key(.x, c2, c3)
     )
   )
+
+  test_tbl <- tibble(nn = 1:5, n = 6:10)
+  expect_silent(
+    check_key(test_tbl, !!!c("n1" = sym("n"), "n2" = sym("nn")))
+  )
+
+  expect_error(
+    check_key(test_tbl, !!!c(sym("n"), sym("nn"))),
+    class = cdm_error("rename_plz")
+  )
 })


### PR DESCRIPTION
`check_key()` now deals correctly with named column lists