### PR TITLE
provide empty 'dm' object

### DIFF
--- a/R/add-tbl.R
+++ b/R/add-tbl.R
@@ -15,9 +15,8 @@
 #'
 #' @export
 cdm_add_tbl <- function(dm, ..., repair = "check_unique") {
-  check_dm(dm)
 
-  orig_tbls <- src_tbls(dm)
+  check_dm(dm)
 
   new_names <- names(exprs(..., .named = TRUE))
   new_tables <- list(...)

--- a/R/dm.R
+++ b/R/dm.R
@@ -600,3 +600,18 @@ all_same_source <- function(tables) {
   first_table <- tables[1][[1]]
   is.null(detect(tables[-1], ~ !same_src(., first_table)))
 }
+
+# creates an empty `dm`-object, `src` is defined by implementation of `cdm_get_src()`.
+empty_dm <- function() {
+  new_dm3(
+    tibble(
+      table = character(),
+      data = list(),
+      segment = logical(),
+      display = character(),
+      pks =vctrs::list_of(new_pk()),
+      fks = vctrs::list_of(new_fk()),
+      filters = vctrs::list_of(new_filter())
+    )
+  )
+}

--- a/R/dm.R
+++ b/R/dm.R
@@ -62,6 +62,7 @@ dm <- nse_function(c(src, data_model = NULL), ~ {
 #' @rdname dm
 #' @export
 new_dm <- function(tables, data_model) {
+  if (is_missing(tables) && is_missing(data_model)) return(empty_dm())
   if (!all_same_source(tables)) abort_not_same_src()
   stopifnot(datamodelr::is.data_model(data_model))
 

--- a/R/dm.R
+++ b/R/dm.R
@@ -4,7 +4,7 @@
 #' The `dm` class wraps [dplyr::src] and adds a description of table relationships
 #' based on [datamodelr::datamodelr-package].
 #'
-#' `dm()` coerces its inputs. If called without parameters, an empty `dm` object is created.
+#' `dm()` coerces its inputs. If called without arguments, an empty `dm` object is created.
 #'
 #' @param src A \pkg{dplyr} table source object.
 #' @param data_model A \pkg{datamodelr} data model object, or `NULL`.
@@ -57,7 +57,7 @@ dm <- nse_function(c(src, data_model = NULL), ~ {
 #' Low-level constructor
 #'
 #' `new_dm()` only checks if the inputs are of the correct class.
-#' If called without parameters, an empty `dm` object is created.
+#' If called without arguments, an empty `dm` object is created.
 #'
 #' @param tables A list of the tables (tibble-objects, not names) to be included in the `dm` object
 #'

--- a/R/dm.R
+++ b/R/dm.R
@@ -4,7 +4,7 @@
 #' The `dm` class wraps [dplyr::src] and adds a description of table relationships
 #' based on [datamodelr::datamodelr-package].
 #'
-#' `dm()` coerces its inputs.
+#' `dm()` coerces its inputs. If called without parameters, an empty `dm` object is created.
 #'
 #' @param src A \pkg{dplyr} table source object.
 #' @param data_model A \pkg{datamodelr} data model object, or `NULL`.
@@ -57,6 +57,8 @@ dm <- nse_function(c(src, data_model = NULL), ~ {
 #' Low-level constructor
 #'
 #' `new_dm()` only checks if the inputs are of the correct class.
+#' If called without parameters, an empty `dm` object is created.
+#'
 #' @param tables A list of the tables (tibble-objects, not names) to be included in the `dm` object
 #'
 #' @rdname dm

--- a/R/dm.R
+++ b/R/dm.R
@@ -38,6 +38,7 @@
 #'   cdm_rename_tbl(ap = airports, fl = flights)
 #' @export
 dm <- nse_function(c(src, data_model = NULL), ~ {
+  if (is_missing(src)) return(empty_dm())
   if (is.null(data_model)) {
     tbl_names <- src_tbls(src)
     tbls <- map(set_names(tbl_names), tbl, src = src)

--- a/R/select-tbl.R
+++ b/R/select-tbl.R
@@ -50,6 +50,7 @@ tidyselect_table_names <- function(dm) {
 
 cdm_select_tbl_impl <- function(dm, selected) {
 
+  # Required to avoid error further below
   if (is_empty(selected)) return(empty_dm())
   check_correct_input(dm, selected)
 

--- a/R/select-tbl.R
+++ b/R/select-tbl.R
@@ -49,6 +49,8 @@ tidyselect_table_names <- function(dm) {
 }
 
 cdm_select_tbl_impl <- function(dm, selected) {
+
+  if (is_empty(selected)) return(empty_dm())
   check_correct_input(dm, selected)
 
   def <-

--- a/man/dm.Rd
+++ b/man/dm.Rd
@@ -46,9 +46,10 @@ as_dm(x)
 The \code{dm} class wraps \link[dplyr:src]{dplyr::src} and adds a description of table relationships
 based on \link[datamodelr:datamodelr-package]{datamodelr::datamodelr-package}.
 
-\code{dm()} coerces its inputs.
+\code{dm()} coerces its inputs. If called without parameters, an empty \code{dm} object is created.
 
 \code{new_dm()} only checks if the inputs are of the correct class.
+If called without parameters, an empty \code{dm} object is created.
 
 \code{validate_dm()} checks consistency between the \pkg{dplyr} source
 and the \pkg{datamodelr} based specification of table relationships.

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -473,7 +473,7 @@ if (is_this_a_test()) {
 
   message("connecting")
 
-  dbplyr::test_register_src("df", src_df(env = new_environment()))
+  dbplyr::test_register_src("df", src_df(env = .GlobalEnv))
 
   if (packageVersion("RSQLite") >= "2.1.1.9003") {
     try(dbplyr::test_register_src("sqlite", src_sqlite(":memory:", create = TRUE)), silent = TRUE)

--- a/tests/testthat/test-add-tbl.R
+++ b/tests/testthat/test-add-tbl.R
@@ -73,6 +73,16 @@ test_that("cdm_add_tbl() works", {
       )
     )
   }
+
+  # adding tables to an empty `dm` works for all sources
+  walk2(
+    data_1_src,
+    test_srcs,
+    ~expect_identical(
+      cdm_add_tbl(dm(), test = ..1) %>% cdm_get_src(),
+      ..2
+    )
+  )
 })
 
 test_that("cdm_rm_tbl() works", {

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -13,3 +13,13 @@ test_that("can create dm with as_dm()", {
     cdm_test_obj_src, ~ expect_equivalent_dm(as_dm(cdm_get_tables(.)), test_obj_df)
   )
 })
+
+test_that("creation of empty `dm` works", {
+  expect_true(
+    is_empty(dm())
+  )
+
+  expect_true(
+    is_empty(new_dm())
+  )
+})


### PR DESCRIPTION
- Empty object can be created via `dm()` and `new_dm()` (without arguments, similar to `numeric()`, `list()`, etc.)
- Allows for creation of a `dm` from scratch, adding tables successively with `cdm_add_tbl()`
- Works locally and on DB
- vignettes have NOT been adapted