### PR TITLE
correctly flatten neighbourhood

### DIFF
--- a/R/disambiguate.R
+++ b/R/disambiguate.R
@@ -45,7 +45,7 @@ compute_disambiguate_cols_recipe <- function(dm, tables, sep) {
   table_colnames %>%
     # in case of flattening, primary key columns will never be responsible for the name
     # of the resulting column in the end, so they do not need to be disambiguated
-    anti_join(pks) %>%
+    anti_join(pks, by = c("table", "column")) %>%
     add_count(column) %>%
     filter(n > 1) %>%
     mutate(new_name = paste0(table, sep, column)) %>%

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -98,7 +98,7 @@ cdm_flatten_to_tbl_impl <- function(dm, start, ..., join, join_name, squash) {
   # If no tables are given, we use all reachable tables
   auto_detect <- is_empty(list_of_pts)
   if (auto_detect) {
-    list_of_pts <- get_names_of_connected(g, start)
+    list_of_pts <- get_names_of_connected(g, start, squash)
   }
   # We use the induced subgraph right away
   g <- igraph::induced_subgraph(g, c(start, list_of_pts))

--- a/R/graph.R
+++ b/R/graph.R
@@ -80,6 +80,7 @@ get_names_of_connected <- function(g, start, squash) {
   if (squash) {
     setdiff(names(dfs[["order"]]), start) %>% discard(is.na)
   } else {
+    # FIXME: Enumerate outgoing edges
     setdiff(names(dfs[["order"]]), c(start, names(dfs$dist[dfs$dist > 1]))) %>% discard(is.na)
   }
 }

--- a/R/graph.R
+++ b/R/graph.R
@@ -74,8 +74,12 @@ create_graph_from_dm <- function(dm, directed = FALSE) {
     igraph::graph_from_data_frame(directed = directed, vertices = def$table)
 }
 
-get_names_of_connected <- function(g, start) {
-  dfs <- igraph::dfs(g, start, unreachable = FALSE)
+get_names_of_connected <- function(g, start, squash) {
+  dfs <- igraph::dfs(g, start, unreachable = FALSE, dist = TRUE)
   # `purrr::discard()` in case `list_of_pts` is `NA`
-  setdiff(names(dfs[["order"]]), start) %>% discard(is.na)
+  if (squash) {
+    setdiff(names(dfs[["order"]]), start) %>% discard(is.na)
+  } else {
+    setdiff(names(dfs[["order"]]), c(start, names(dfs$dist[dfs$dist > 1]))) %>% discard(is.na)
+  }
 }

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -62,6 +62,7 @@ test_that("`cdm_flatten_to_tbl()` does the right things for 'left_join()'", {
 
   # deeper hierarchy available and `auto_detect = TRUE`
   # for flatten: columns from t5 + t4 + t4_2 + t6 are combined in one table, 8 cols in total
+  # FIXME: expect_length(...)
   expect_identical(
     length(colnames(cdm_flatten_to_tbl(dm_more_complex, t5))),
     8L
@@ -288,6 +289,7 @@ test_that("`cdm_squash_to_tbl()` does the right things", {
 
   # deeper hierarchy available and `auto_detect = TRUE`
   # for flatten: columns from t5 + t4 + t3 + t4_2 + t6 are combined in one table, 9 cols in total
+  # FIXME: expect_length(...)
   expect_identical(
     length(colnames(cdm_squash_to_tbl(dm_more_complex, t5))),
     9L

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -60,6 +60,13 @@ test_that("`cdm_flatten_to_tbl()` does the right things for 'left_join()'", {
     class = cdm_error("tables_not_reachable_from_start")
   )
 
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from t5 + t4 + t4_2 + t6 are combined in one table, 8 cols in total
+  expect_identical(
+    length(colnames(cdm_flatten_to_tbl(dm_more_complex, t5))),
+    8L
+  )
+
 })
 
 test_that("`cdm_flatten_to_tbl()` does the right things for 'inner_join()'", {
@@ -278,6 +285,13 @@ test_that("`cdm_squash_to_tbl()` does the right things", {
     left_join(t5, t4, by = c("l" = "h")) %>%
       left_join(t3, by = c("j" = "f"))
     )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from t5 + t4 + t3 + t4_2 + t6 are combined in one table, 9 cols in total
+  expect_identical(
+    length(colnames(cdm_squash_to_tbl(dm_more_complex, t5))),
+    9L
+  )
 
   # full_join:
   expect_identical(


### PR DESCRIPTION
- `cdm_flatten_to_tbl()` determines now the correct neighbourhood
- avoided the meaningless message ("Joining, by ...") when calling `cdm_flatten_to_tbl()` or `cdm_squash_to_tbl()`

fixes #95 