### PR TITLE
bugfix for 'cdm_add_tbl()'

### DIFF
--- a/R/add-tbl.R
+++ b/R/add-tbl.R
@@ -41,6 +41,9 @@ cdm_add_tbl_impl <- function(dm, tbls, table_name) {
   def_0 <- def[rep_along(table_name, NA_integer_), ]
   def_0$table <- table_name
   def_0$data <- tbls
+  def_0$pks <- vctrs::list_of(new_pk())
+  def_0$fks <- vctrs::list_of(new_fk())
+  def_0$filters <- vctrs::list_of(new_filter())
 
   new_dm3(vctrs::vec_rbind(def, def_0))
 }

--- a/tests/testthat/test-add-tbl.R
+++ b/tests/testthat/test-add-tbl.R
@@ -83,6 +83,11 @@ test_that("cdm_add_tbl() works", {
       ..2
     )
   )
+
+  # can I use cdm_select_tbl(), selecting among others the new table?
+  expect_silent(
+    cdm_add_tbl(dm_for_filter, t7_new = t7) %>% cdm_select_tbl(t1, t7_new, everything())
+  )
 })
 
 test_that("cdm_rm_tbl() works", {


### PR DESCRIPTION
- consistent types in `def` columns

(e.g. `cdm_select_tbl()` doesn't work otherwise)