### PR TITLE
avoid 'cdm_get_data_model()' in vignettes

### DIFF
--- a/vignettes/dm-class-and-basic-operations.Rmd
+++ b/vignettes/dm-class-and-basic-operations.Rmd
@@ -76,21 +76,23 @@ iris_dm <- as_dm(list("iris1" = iris, "iris2" = iris))
 iris_dm
 ```
 
-And lastly, with `new_dm()` you can create a `dm` by providing the three individual parts it consists of:
-```{r}
-local_src <- src_df(env = new.env())
-tables <- list("iris1" = iris, "iris2" = iris)
-data_model <- cdm_get_data_model(iris_dm)
-another_iris_dm <- 
-  new_dm(
-    tables = tables,
-    data_model = data_model
-    )
-another_iris_dm
-```
+<!-- And lastly, with `new_dm()` you can create a `dm` by providing the three individual parts it consists of: -->
+<!-- ```{r} -->
+<!-- local_src <- src_df(env = new.env()) -->
+<!-- tables <- list("iris1" = iris, "iris2" = iris) -->
+<!-- data_model <- cdm_get_data_model(iris_dm) -->
+<!-- another_iris_dm <-  -->
+<!--   new_dm( -->
+<!--     tables = tables, -->
+<!--     data_model = data_model -->
+<!--     ) -->
+<!-- another_iris_dm -->
+<!-- ``` -->
 
-You saw, that with `cdm_get_data_model()` we access the `data_model` part of a `dm`.
-Similarly, we can get the list of tables with `cdm_get_tables()` and the `src` object with `cdm_get_src()`.
+<!-- You saw, that with `cdm_get_data_model()` we access the `data_model` part of a `dm`. -->
+<!-- Similarly, we can get the list of tables with `cdm_get_tables()` and the `src` object with `cdm_get_src()`. -->
+
+We can get the list of tables with `cdm_get_tables()` and the `src` object with `cdm_get_src()`.
 
 In order to pull a specific table from a `dm`, use:
 ```{r}

--- a/vignettes/dm.Rmd
+++ b/vignettes/dm.Rmd
@@ -74,23 +74,14 @@ flights_dm <- dm(src_df(pkg = "nycflights13"))
 flights_dm
 ```
 
-The fairly verbose output shows the three components of a `dm` object: the table source, the metadata, and row counts.
-These components can be accessed with `cdm_get_src()`, `cdm_get_tables()` and `cdm_get_data_model()`.
+The fairly verbose output shows an overview of various components of a `dm` object: the table source, the metadata, and filter conditions.
+These components can be individually accessed with several {dm}-functions, e.g. `cdm_get_src()`, `cdm_get_filter()`, `cdm_get_all_pks()` and `cdm_get_all_fks()`.
 
 ```{r}
 cdm_get_src(flights_dm)
-```
-
-
-```{r}
-# Querying nrow() for each table, to suppress otherwise huge output
-cdm_get_tables(flights_dm) %>% 
-  map_int(nrow)
-```
-
-
-```{r}
-cdm_get_data_model(flights_dm)
+cdm_get_filter(flights_dm)
+cdm_get_all_pks(flights_dm)
+cdm_get_all_fks(flights_dm)
 ```
 
 


### PR DESCRIPTION
This is just a hotfix, so R_CMD_check doesn't throw an error. We need to rework the vignettes as soon as we're at a stable state