### PR TITLE
Bugfix: `cdm_select_tbl()` with multi-FKs between 2 tables

### DIFF
--- a/R/select-tbl.R
+++ b/R/select-tbl.R
@@ -72,16 +72,19 @@ filter_recode_table_fks <- function(def, selected) {
 }
 
 filter_recode_table_def <- function(data, selected) {
+  # We want to keep the order mentioned in `selected` here.
+  # data$table only contains unique values by definition.
   idx <- match(selected, data$table, nomatch = 0L)
+
   data[idx, ] %>%
     mutate(table = recode(table, !!!prep_recode(selected)))
 }
 
 filter_recode_fks_of_table <- function(data, selected) {
+  # data$table can have multiple entries, we don't care about the order
   idx <- data$table %in% selected
   data[idx, ] %>%
     mutate(table = recode(table, !!!prep_recode(selected)))
-
 }
 
 prep_recode <- function(x) {

--- a/R/select-tbl.R
+++ b/R/select-tbl.R
@@ -72,7 +72,7 @@ filter_recode_table_fks <- function(def, selected) {
 }
 
 filter_recode_table_def <- function(data, selected) {
-  idx <- map_int(selected, ~which(data$table == .))
+  idx <- match(selected, data$table, nomatch = 0L)
   data[idx, ] %>%
     mutate(table = recode(table, !!!prep_recode(selected)))
 }

--- a/R/select-tbl.R
+++ b/R/select-tbl.R
@@ -72,7 +72,7 @@ filter_recode_table_fks <- function(def, selected) {
 }
 
 filter_recode_table <- function(data, selected) {
-  idx <- match(selected, data$table, nomatch = 0L)
+  idx <- map(unname(selected), ~which(data$table == .)) %>% flatten_int()
   data[idx, ] %>%
     mutate(table = recode(table, !!!prep_recode(selected)))
 }

--- a/R/select-tbl.R
+++ b/R/select-tbl.R
@@ -72,9 +72,11 @@ filter_recode_table_fks <- function(def, selected) {
 }
 
 filter_recode_table <- function(data, selected) {
-  idx <- map(unname(selected), ~which(data$table == .)) %>% flatten_int()
-  data[idx, ] %>%
-    mutate(table = recode(table, !!!prep_recode(selected)))
+  filter(data, table %in% selected) %>%
+    mutate(table_fct = ordered(table, levels = selected)) %>%
+    arrange(sort.int(table_fct, index.return = TRUE)$ix) %>%
+    mutate(table = recode(table, !!!prep_recode(selected))) %>%
+    select(-table_fct)
 }
 
 prep_recode <- function(x) {

--- a/tests/testthat/test-select-tbl.R
+++ b/tests/testthat/test-select-tbl.R
@@ -24,6 +24,21 @@ test_that("cdm_select_tbl() can reorder the tables in a `dm`", {
   )
 })
 
+test_that("cdm_select_tbl() remembers all FKs", {
+  reordered_dm_nycflights_small_cycle <- cdm_add_fk(dm_nycflights_small, flights, origin, airports) %>%
+    cdm_get_def() %>%
+    filter(!(table %in% c("airlines", "planes"))) %>%
+    arrange(2:1) %>%
+    new_dm3()
+
+  expect_equivalent_dm(
+    cdm_add_fk(dm_nycflights_small, flights, origin, airports) %>%
+    cdm_select_tbl(airports, flights),
+    reordered_dm_nycflights_small_cycle
+  )
+})
+
+
 test_that("cdm_rename_tbl() renames a `dm`", {
 
   dm_rename <-


### PR DESCRIPTION
currently on master:
``` r
library(dm)
#> 
#> Attaching package: 'dm'
#> The following object is masked from 'package:stats':
#> 
#>     filter
cdm_nycflights13(cycle = TRUE) %>% cdm_draw()
```

![](https://i.imgur.com/mfNvewS.png)

``` r
cdm_select_tbl(cdm_nycflights13(cycle = TRUE), flights, airports) %>% cdm_draw()
```

![](https://i.imgur.com/c8JKL3E.png)

<sup>Created on 2019-11-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

in this branch:
``` r
library(dm)
#> 
#> Attaching package: 'dm'
#> The following object is masked from 'package:stats':
#> 
#>     filter
cdm_nycflights13(cycle = TRUE) %>% cdm_draw()
```

![](https://i.imgur.com/bzcaM70.png)

``` r
cdm_select_tbl(cdm_nycflights13(cycle = TRUE), flights, airports) %>% cdm_draw()
```

![](https://i.imgur.com/4j2YgdI.png)

<sup>Created on 2019-11-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>