### PR TITLE
instant filter for filter-table

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -137,8 +137,8 @@ new_dm <- function(tables, data_model) {
 
   filters <-
     filter %>%
-    rename(filter_quo = filter) %>%
-    nest(filters = filter_quo)
+    rename(filter_expr = filter) %>%
+    nest(filters = filter_expr)
 
   filters <-
     tibble(
@@ -183,7 +183,7 @@ new_fk <- function(table = character(), column = list()) {
 }
 
 new_filter <- function(quos = list(), zoomed = logical()) {
-  tibble(filter_quo = unclass(quos), zoomed = zoomed)
+  tibble(filter_expr = unclass(quos), zoomed = zoomed)
 }
 
 # Legacy!
@@ -328,12 +328,12 @@ cdm_get_filter <- function(x) {
     unnest(filters)
 
   # FIXME: Should work better with dplyr 0.9.0
-  if (!("filter_quo" %in% names(filter_df))) {
-    filter_df$filter_quo <- list()
+  if (!("filter_expr" %in% names(filter_df))) {
+    filter_df$filter_expr <- list()
   }
 
   filter_df  %>%
-    rename(filter = filter_quo)
+    rename(filter = filter_expr)
 }
 
 cdm_get_zoomed_tbl <- function(x) {

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -26,7 +26,6 @@ ungroup.zoomed_dm <- function(x, ...) {
 
 #' @export
 summarise.zoomed_dm <- function(.data, ...) {
-  if (nrow(cdm_get_filter(.data) %>% filter(table == !!orig_name_zoomed(.data)))) abort_no_filters_rename_select()
   tbl <- get_zoomed_tbl(.data)
   # groups are "selected"; key tracking will continue for them
   groups <- set_names(map_chr(groups(tbl), as_string))
@@ -68,7 +67,6 @@ mutate.dm <- function(.data, ...) {
 
 #' @export
 mutate.zoomed_dm <- function(.data, ...) {
-  if (nrow(cdm_get_filter(.data) %>% filter(table == !!orig_name_zoomed(.data)))) abort_no_filters_rename_select()
   tbl <- get_zoomed_tbl(.data)
   mutated_tbl <- mutate(tbl, ...)
   # all columns that are not touched count as "selected"; names of "selected" are identical to "selected"
@@ -84,7 +82,6 @@ transmute.dm <- function(.data, ...) {
 
 #' @export
 transmute.zoomed_dm <- function(.data, ...) {
-  if (nrow(cdm_get_filter(.data) %>% filter(table == !!orig_name_zoomed(.data)))) abort_no_filters_rename_select()
   tbl <- get_zoomed_tbl(.data)
   # groups are "selected"; key tracking will continue for them
   groups <- set_names(map_chr(groups(tbl), as_string))
@@ -101,7 +98,6 @@ select.dm <- function(.data, ...) {
 
 #' @export
 select.zoomed_dm <- function(.data, ...) {
-  if (nrow(cdm_get_filter(.data) %>% filter(table == !!orig_name_zoomed(.data)))) abort_no_filters_rename_select()
   tbl <- get_zoomed_tbl(.data)
   selected <- tidyselect::vars_select(colnames(tbl), ...)
   selected_tbl <- select(tbl, !!!selected)
@@ -118,7 +114,6 @@ rename.dm <- function(.data, ...) {
 
 #' @export
 rename.zoomed_dm <- function(.data, ...) {
-  if (nrow(cdm_get_filter(.data) %>% filter(table == !!orig_name_zoomed(.data)))) abort_no_filters_rename_select()
   tbl <- get_zoomed_tbl(.data)
   renamed <- tidyselect::vars_rename(colnames(tbl), ...)
   renamed_tbl <- rename(tbl, !!!renamed)

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -46,17 +46,17 @@ filter.dm <- function(.data, ...) {
 
 #' @export
 filter.zoomed_dm <- function(.data, ...) {
-  filter_exprs <- enexprs(...)
-  if (is_empty(filter_exprs)) {
+  filter_quos <- enquos(...)
+  if (is_empty(filter_quos)) {
     return(.data)
   } # valid table and empty ellipsis provided
 
   tbl <- get_zoomed_tbl(.data)
-  filtered_tbl <- filter(tbl, ...)
+  filtered_tbl <- filter(tbl, !!!filter_quos)
 
   # attribute filter expression to zoomed table. Needs to be flagged with `zoomed = TRUE`, since
   # in case of `cdm_insert_zoomed_tbl()` the filter exprs needs to be transferred
-  set_filter_for_table(.data, orig_name_zoomed(.data), filter_exprs, TRUE) %>%
+  set_filter_for_table(.data, orig_name_zoomed(.data), map(filter_quos, quo_get_expr), TRUE) %>%
     replace_zoomed_tbl(filtered_tbl)
 }
 

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -47,12 +47,18 @@ filter.dm <- function(.data, ...) {
 
 #' @export
 filter.zoomed_dm <- function(.data, ...) {
-  quos <- enquos(...)
-  if (is_empty(quos)) {
+  filter_exprs <- enexprs(...)
+  if (is_empty(filter_exprs)) {
     return(.data)
   } # valid table and empty ellipsis provided
 
-  set_filter_for_table(.data, orig_name_zoomed(.data), quos, TRUE)
+  tbl <- get_zoomed_tbl(.data)
+  filtered_tbl <- filter(tbl, ...)
+
+  # attribute filter expression to zoomed table. Needs to be flagged with `zoomed = TRUE`, since
+  # in case of `cdm_insert_zoomed_tbl()` the filter exprs needs to be transferred
+  set_filter_for_table(.data, orig_name_zoomed(.data), filter_exprs, TRUE) %>%
+    replace_zoomed_tbl(filtered_tbl)
 }
 
 #' @export

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -535,19 +535,6 @@ error_no_table_zoomed_dplyr <- function(fun) {
        "when calling {tick(paste0(fun, '()'))} on a `dm`")
 }
 
-
-# no filters can exist for zoomed table for 'rename()' and 'select --------
-
-abort_no_filters_rename_select <- function() {
-  abort(error_no_filters_rename_select(), .subclass = cdm_error_full("no_filters_rename_select"))
-}
-
-error_no_filters_rename_select <- function() {
-  paste0("No existing filter conditions allowed for both the zoomed table or the original table that was zoomed ",
-         "when calling `rename.zoomed_dm()`, `select.zoomed_dm()`, `mutate.zoomed_dm()`, `summarise.zoomed_dm()` or ",
-         "`transmute.zoomed_dm()`.")
-}
-
 # when zoomed and it shouldn't be ------------------------------
 
 abort_only_possible_wo_zoom <- function(fun_name) {

--- a/R/filter-dm.R
+++ b/R/filter-dm.R
@@ -98,7 +98,8 @@ cdm_apply_filters <- function(dm) {
   cdm_reset_all_filters(new_dm3(def))
 }
 
-
+# calculates the necessary semi-joins from all tables that were filtered to
+# the requested table
 cdm_get_filtered_table <- function(dm, from) {
   filters <- cdm_get_filter(dm)
   if (nrow(filters) == 0) {
@@ -106,9 +107,6 @@ cdm_get_filtered_table <- function(dm, from) {
   }
 
   fc <- get_all_filtered_connected(dm, from)
-
-  f_quos <- filters %>%
-    nest(filter = -table)
 
   fc_children <-
     fc %>%
@@ -120,8 +118,7 @@ cdm_get_filtered_table <- function(dm, from) {
   recipe <-
     fc %>%
     select(table = node) %>%
-    left_join(fc_children, by = "table") %>%
-    left_join(f_quos, by = "table")
+    left_join(fc_children, by = "table")
 
   list_of_tables <- cdm_get_tables(dm)
 
@@ -140,13 +137,6 @@ cdm_get_filtered_table <- function(dm, from) {
           .init = table
         )
     }
-
-    filter_quos <- recipe$filter[[i]]
-    if (!is_null(filter_quos)) {
-      filter_quos <- pull(filter_quos, filter)
-      table <- filter(table, !!!filter_quos)
-    }
-
     list_of_tables[[table_name]] <- table
   }
   list_of_tables[[from]]

--- a/R/filter-dm.R
+++ b/R/filter-dm.R
@@ -18,7 +18,7 @@
 #' of semi-joins ([`dplyr::semi_join()`]) starting from each table that has been filtered to the requested table
 #' (similar to 1. but only for one table).
 #'
-#' Several functions of the {dm} package will throw an error if unevaluated filter conditions exist when they are called.
+#' Several functions of the {dm} package will throw an error if filter conditions exist when they are called.
 #' @rdname cdm_filter
 #'
 #' @inheritParams cdm_add_pk

--- a/R/filter-dm.R
+++ b/R/filter-dm.R
@@ -61,12 +61,9 @@ cdm_filter <- function(dm, table, ...) {
   table <- as_name(ensym(table))
   check_correct_input(dm, table)
 
-  quos <- enquos(...)
-  if (is_empty(quos)) {
-    return(dm)
-  } # valid table and empty ellipsis provided
-
-  set_filter_for_table(dm, table, quos, FALSE)
+  cdm_zoom_to_tbl(dm, !!table) %>%
+    filter(...) %>%
+    cdm_update_zoomed_tbl()
 }
 
 set_filter_for_table <- function(dm, table, filter_exprs, zoomed) {

--- a/R/filter-dm.R
+++ b/R/filter-dm.R
@@ -2,21 +2,21 @@
 #'
 #' Filtering one table of a [`dm`] object may affect all tables connected to this table
 #' via one or more steps of foreign key relations. Firstly, one or more filter conditions for
-#' one or more tables can be defined using `cdm_filter()`, with a syntax similar to `dplyr::filter()`.
-#' These conditions will be stored in the [`dm`] and not immediately executed. With `cdm_apply_filters()`
-#' all tables will be updated according to the filter conditions and the foreign key relations.
+#' one or more tables can be defined using `cdm_filter()`, with a syntax similar to [`dplyr::filter()`].
+#' Each condition will only be immediately executed for the table it is referring to.
+#' Furthermore all conditions are stored in the [`dm`].
+#' With `cdm_apply_filters()` all tables will be updated according to the filter conditions and the foreign key relations.
 #'
-#'
-#' @details `cdm_filter()` allows you to set one or more filter conditions for one table
-#' of a [`dm`] object. These conditions will be stored in the [`dm`] for when they are needed.
-#' The conditions are only evaluated in one of the following scenarios:
+#' @details The effect of the stored filter conditions on the tables related to the filtered ones is only evaluated
+#' in one of the following scenarios:
 #' 1. Calling `cdm_apply_filters()` or `compute()` (method for `dm` objects) on a `dm`: each filtered table potentially
 #' reduces the rows of all other tables connected to it by foreign key relations (cascading effect), only leaving the rows
 #' with the corresponding key values.
 #' Tables that are not connected to any table with an active filter are left unchanged.
-#' This results in a new `dm` class object.
-#' 1. Calling one of `tbl()`, `[[.dm()`, `$.dm()`: the remaining rows of the requested table are calculated based on the
-#' filter conditions and the foreign key conditions (similar to 1. but only for one table)
+#' This results in a new `dm` class object without any filter conditions.
+#' 1. Calling one of `tbl()`, `[[.dm()`, `$.dm()`: the remaining rows of the requested table are calculated by performing a sequence
+#' of semi-joins ([`dplyr::semi_join()`]) starting from each table that has been filtered to the requested table
+#' (similar to 1. but only for one table).
 #'
 #' Several functions of the {dm} package will throw an error if unevaluated filter conditions exist when they are called.
 #' @rdname cdm_filter

--- a/R/filter-dm.R
+++ b/R/filter-dm.R
@@ -69,11 +69,11 @@ cdm_filter <- function(dm, table, ...) {
   set_filter_for_table(dm, table, quos, FALSE)
 }
 
-set_filter_for_table <- function(dm, table, quos, zoomed) {
+set_filter_for_table <- function(dm, table, filter_exprs, zoomed) {
   def <- cdm_get_def(dm)
 
   i <- which(def$table == table)
-  def$filters[[i]] <- vctrs::vec_rbind(def$filters[[i]], new_filter(quos, zoomed))
+  def$filters[[i]] <- vctrs::vec_rbind(def$filters[[i]], new_filter(filter_exprs, zoomed))
   new_dm3(def, zoomed = zoomed)
 }
 

--- a/R/filter-helpers.R
+++ b/R/filter-helpers.R
@@ -5,6 +5,8 @@
 #' @param dm A [`dm`] object
 #' @export
 cdm_nrow <- function(dm) {
+  # FIXME: with "direct" filter maybe no check necessary: but do we want to issue
+  # a message in case the filters haven't been applied yet?
   check_no_filter(dm)
   map_dbl(cdm_get_tables(dm), ~ as.numeric(pull(collect(count(.)))))
 }

--- a/R/filter-helpers.R
+++ b/R/filter-helpers.R
@@ -22,6 +22,7 @@ get_by <- function(dm, lhs_name, rhs_name) {
     abort_tables_not_neighbours(lhs_name, rhs_name)
   }
 
+  if (length(lhs_col) > 1 || length(rhs_col) > 1) abort_no_cycles()
   # Construct a `by` argument of the form `c("lhs_col[1]" = "rhs_col[1]", ...)`
   # as required by `*_join()`
   by <- rhs_col

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -191,6 +191,8 @@ cdm_rm_fk <- function(dm, table, column, ref_table) {
 #'
 #' @export
 cdm_enum_fk_candidates <- nse_function(c(dm, table, ref_table), ~ {
+  # FIXME: with "direct" filter maybe no check necessary: but do we want to check
+  # for tables retrieved with `tbl()` or with `cdm_get_tables()[[table_name]]`
   check_no_filter(dm)
 
   table_name <- as_string(ensym(table))

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -212,6 +212,8 @@ enum_pk_candidates <- nse_function(c(table), ~ {
 #' cdm_nycflights13() %>% cdm_enum_pk_candidates(flights)
 #' cdm_nycflights13() %>% cdm_enum_pk_candidates(airports)
 cdm_enum_pk_candidates <- nse_function(c(dm, table), ~ {
+  # FIXME: with "direct" filter maybe no check necessary: but do we want to check
+  # for tables retrieved with `tbl()` or with `cdm_get_tables()[[table_name]]`
   check_no_filter(dm)
 
   table_name <- as_name(ensym(table))

--- a/R/select-tbl.R
+++ b/R/select-tbl.R
@@ -30,8 +30,6 @@ cdm_select_tbl <- function(dm, ...) {
 #' @rdname cdm_select_tbl
 #' @export
 cdm_rename_tbl <- function(dm, ...) {
-  check_no_filter(dm)
-
   vars <- tidyselect_table_names(dm)
   selected <- tidyselect::vars_rename(vars, ...)
   cdm_select_tbl_impl(dm, selected)

--- a/R/select.R
+++ b/R/select.R
@@ -22,8 +22,6 @@
 #'   cdm_rename(airports, code = faa, altitude = alt)
 #' @export
 cdm_rename <- function(dm, table, ...) {
-  check_no_filter(dm)
-
   table_name <- as_string(ensym(table))
 
   cdm_zoom_to_tbl(dm, !!table_name) %>%
@@ -45,8 +43,6 @@ cdm_rename <- function(dm, table, ...) {
 #'
 #' @export
 cdm_select <- function(dm, table, ...) {
-  check_no_filter(dm)
-
   table_name <- as_string(ensym(table))
 
   cdm_zoom_to_tbl(dm, !!table_name) %>%

--- a/man/cdm_filter.Rd
+++ b/man/cdm_filter.Rd
@@ -44,7 +44,7 @@ of semi-joins (\code{\link[dplyr:semi_join]{dplyr::semi_join()}}) starting from 
 (similar to 1. but only for one table).
 }
 
-Several functions of the {dm} package will throw an error if unevaluated filter conditions exist when they are called.
+Several functions of the {dm} package will throw an error if filter conditions exist when they are called.
 }
 \examples{
 library(dplyr)

--- a/man/cdm_filter.Rd
+++ b/man/cdm_filter.Rd
@@ -25,22 +25,23 @@ for an introduction to these concepts.}
 \description{
 Filtering one table of a \code{\link{dm}} object may affect all tables connected to this table
 via one or more steps of foreign key relations. Firstly, one or more filter conditions for
-one or more tables can be defined using \code{cdm_filter()}, with a syntax similar to \code{dplyr::filter()}.
-These conditions will be stored in the \code{\link{dm}} and not immediately executed. With \code{cdm_apply_filters()}
-all tables will be updated according to the filter conditions and the foreign key relations.
+one or more tables can be defined using \code{cdm_filter()}, with a syntax similar to \code{\link[dplyr:filter]{dplyr::filter()}}.
+Each condition will only be immediately executed for the table it is referring to.
+Furthermore all conditions are stored in the \code{\link{dm}}.
+With \code{cdm_apply_filters()} all tables will be updated according to the filter conditions and the foreign key relations.
 }
 \details{
-\code{cdm_filter()} allows you to set one or more filter conditions for one table
-of a \code{\link{dm}} object. These conditions will be stored in the \code{\link{dm}} for when they are needed.
-The conditions are only evaluated in one of the following scenarios:
+The effect of the stored filter conditions on the tables related to the filtered ones is only evaluated
+in one of the following scenarios:
 \enumerate{
 \item Calling \code{cdm_apply_filters()} or \code{compute()} (method for \code{dm} objects) on a \code{dm}: each filtered table potentially
 reduces the rows of all other tables connected to it by foreign key relations (cascading effect), only leaving the rows
 with the corresponding key values.
 Tables that are not connected to any table with an active filter are left unchanged.
-This results in a new \code{dm} class object.
-\item Calling one of \code{tbl()}, \code{[[.dm()}, \code{$.dm()}: the remaining rows of the requested table are calculated based on the
-filter conditions and the foreign key conditions (similar to 1. but only for one table)
+This results in a new \code{dm} class object without any filter conditions.
+\item Calling one of \code{tbl()}, \code{[[.dm()}, \code{$.dm()}: the remaining rows of the requested table are calculated by performing a sequence
+of semi-joins (\code{\link[dplyr:semi_join]{dplyr::semi_join()}}) starting from each table that has been filtered to the requested table
+(similar to 1. but only for one table).
 }
 
 Several functions of the {dm} package will throw an error if unevaluated filter conditions exist when they are called.

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -237,4 +237,14 @@ test_that("key tracking works", {
       cdm_get_fk(t4, t3),
     character()
   )
+
+  # it should be possible to combine 'filter' on a zoomed_dm with all other dplyr-methods; example: 'rename'
+  expect_equivalent_dm(
+    cdm_zoom_to_tbl(dm_for_filter, t2) %>%
+      filter(d < 6) %>%
+      rename(c_new = c, d_new = d) %>%
+      cdm_update_zoomed_tbl(),
+    cdm_filter(dm_for_filter, t2, d < 6) %>%
+      cdm_rename(t2, c_new = c, d_new = d)
+  )
 })

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -338,6 +338,7 @@ test_that("prepare_dm_for_flatten() works", {
   red_dm <- cdm_select_tbl(dm_for_flatten, fact, dim_1, dim_3)
   tables <- cdm_get_tables(red_dm)
   tables[["fact"]] <- filter(tables[["fact"]], dim_1_key > 7)
+  tables[["dim_1"]] <- filter(tables[["dim_1"]], dim_1_pk > 7)
 
   def <- cdm_get_def(red_dm)
   def$data <- tables


### PR DESCRIPTION
when setting a filter (either with `cdm_filter()` or `cdm_zoom_to_tbl()` - `filter()`) the table that is filtered will be actually filtered immediately. In addition, the filter-expression is stored.

1. users can still access their filter conditions (also available in `print()`-method)
2. no problems anymore with changing column names etc.
3. effect on all other tables needs to be invoked via `cdm_apply_filters()` or `compute.dm()`

fixes #124 
fixes #113 ?