### PR TITLE
bugfix: 'mutate.zoomed_dm()' when no keys are tracked

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -68,9 +68,11 @@ mutate.dm <- function(.data, ...) {
 #' @export
 mutate.zoomed_dm <- function(.data, ...) {
   tbl <- get_zoomed_tbl(.data)
-  mutated_tbl <- mutate(tbl, ...)
+  quos <- enquos(...)
+  mutated_tbl <- mutate(tbl, !!!quos)
   # all columns that are not touched count as "selected"; names of "selected" are identical to "selected"
-  selected <- set_names(setdiff(names(get_tracked_keys(.data)), names(enquos(..., .named = TRUE))))
+  # in case no keys are tracked, `set_names(NULL)` would throw an error
+  selected <- set_names(setdiff(names2(get_tracked_keys(.data)), names(quos)))
   new_tracked_keys_zoom <- new_tracked_keys(.data, selected)
   replace_zoomed_tbl(.data, mutated_tbl, new_tracked_keys_zoom)
 }

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -68,7 +68,7 @@ mutate.dm <- function(.data, ...) {
 #' @export
 mutate.zoomed_dm <- function(.data, ...) {
   tbl <- get_zoomed_tbl(.data)
-  quos <- enquos(...)
+  quos <- enquos(..., .named = TRUE)
   mutated_tbl <- mutate(tbl, !!!quos)
   # all columns that are not touched count as "selected"; names of "selected" are identical to "selected"
   # in case no keys are tracked, `set_names(NULL)` would throw an error

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -184,7 +184,7 @@ get_tracked_keys <- function(dm) {
   cdm_get_def(dm) %>%
     filter(table == orig_name_zoomed(dm)) %>%
     pull(key_tracker_zoom) %>%
-    pluck(1)
+    extract2(1)
 }
 
 orig_name_zoomed <- function(dm) {

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -430,7 +430,8 @@ dm_nycflights_small %<-% {as_dm(
     flights = nycflights13::flights %>% slice(1:800),
     planes = nycflights13::planes,
     airlines = nycflights13::airlines,
-    airports = nycflights13::airports)
+    airports = nycflights13::airports,
+    weather = nycflights13::weather %>% slice(1:800))
   ) %>%
   cdm_add_pk(planes, tailnum) %>%
   cdm_add_pk(airlines, carrier) %>%

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -238,6 +238,28 @@ test_that("key tracking works", {
     character()
   )
 
+  # keys tracking when there are no keys to track
+  expect_identical(
+    cdm_zoom_to_tbl(dm_nycflights_small, weather) %>%
+      mutate(time_hour_fmt = format(time_hour, tz = "UTC")) %>%
+      get_zoomed_tbl(),
+    tbl(dm_nycflights_small, "weather") %>% mutate(time_hour_fmt = format(time_hour, tz = "UTC"))
+  )
+
+  expect_identical(
+    cdm_zoom_to_tbl(dm_nycflights_small, weather) %>%
+      summarize(avg_wind_speed = mean(wind_speed)) %>%
+      get_zoomed_tbl(),
+    tbl(dm_nycflights_small, "weather") %>% summarize(avg_wind_speed = mean(wind_speed))
+  )
+
+  expect_identical(
+    cdm_zoom_to_tbl(dm_nycflights_small, weather) %>%
+      transmute(celsius_temp = (temp - 32) * 5/9) %>%
+      get_zoomed_tbl(),
+    tbl(dm_nycflights_small, "weather") %>% transmute(celsius_temp = (temp - 32) * 5/9)
+  )
+
   # it should be possible to combine 'filter' on a zoomed_dm with all other dplyr-methods; example: 'rename'
   expect_equivalent_dm(
     cdm_zoom_to_tbl(dm_for_filter, t2) %>%

--- a/tests/testthat/test-select-tbl.R
+++ b/tests/testthat/test-select-tbl.R
@@ -28,7 +28,7 @@ test_that("cdm_select_tbl() remembers all FKs", {
   reordered_dm_nycflights_small_cycle <- cdm_add_fk(dm_nycflights_small, flights, origin, airports) %>%
     cdm_get_def() %>%
     filter(!(table %in% c("airlines", "planes"))) %>%
-    arrange(2:1) %>%
+    slice(2:1) %>%
     new_dm3()
 
   expect_equivalent_dm(


### PR DESCRIPTION
problem was `set_names(NULL)` would throw an error

- helper function `set_names_or_null()`
- test for the failing case

@krlmlr this patch is necessary for the demo.