### PR TITLE
Bugfix: key tracking for 'slice()'-method

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -159,19 +159,17 @@ slice.dm <- function(.data, ...) {
 #' @export
 slice.zoomed_dm <- function(.data, idx) {
   if (is_missing(idx)) return(.data)
-
+  # we want to exclude errors triggered from {vctrs}, since hard to interpret and catching would need case differentiation, i.e. check first
   if (!inherits(idx, "integer")) {
-    # numeric vector only accepted if identical to itself as integer
-    if (!inherits(idx, "numeric") || !all(as.integer(idx) == idx)) abort_need_int(class(idx))
+    if (!inherits(idx, "numeric") || !all(as.integer(idx) == idx)) abort_need_int(class(idx)) else idx <- as.integer(idx)
   }
+  idx <- vctrs::vec_as_index(idx, nrow(.data))
   # FIXME: will be easier if we have an extra row in `def` for the zoomed table
-  if (cdm_has_pk(.data, !!orig_name_zoomed(.data))) {
-    orig_pk <- cdm_get_pk(.data, !!orig_name_zoomed(.data))
-    tracked_keys <- get_tracked_keys(.data)
-    # drop tracking PK if duplicated positive indices exist
-    new_tracked_keys_zoom <- if (anyDuplicated(idx) && idx[1] > 0) discard(tracked_keys, tracked_keys == orig_pk) else tracked_keys
-    replace_zoomed_tbl(.data, slice(get_zoomed_tbl(.data), idx), new_tracked_keys_zoom)
-  } else replace_zoomed_tbl(.data, slice(get_zoomed_tbl(.data), idx))
+  orig_pk <- cdm_get_pk(.data, !!orig_name_zoomed(.data))
+  tracked_keys <- get_tracked_keys(.data)
+  # drop tracking PK if duplicated positive indices exist
+  new_tracked_keys_zoom <- if (anyDuplicated(idx)) discard(tracked_keys, tracked_keys == orig_pk) else tracked_keys
+  replace_zoomed_tbl(.data, slice(get_zoomed_tbl(.data), idx), new_tracked_keys_zoom)
 }
 
 #' @export

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -157,8 +157,20 @@ slice.dm <- function(.data, ...) {
 }
 
 #' @export
-slice.zoomed_dm <- function(.data, ...) {
-  replace_zoomed_tbl(.data, slice(get_zoomed_tbl(.data), ...))
+slice.zoomed_dm <- function(.data, idx) {
+
+  if (!inherits(idx, "integer")) {
+    # numeric vector only accepted if identical to itself as integer
+    if (inherits(idx, "numeric") && !all(as.integer(idx) == idx)) abort_need_int(class(idx))
+  }
+  # FIXME: will be easier if we have an extra row in `def` for the zoomed table
+  if (cdm_has_pk(.data, !!orig_name_zoomed(.data))) {
+    orig_pk <- cdm_get_pk(.data, !!orig_name_zoomed(.data))
+    tracked_keys <- get_tracked_keys(.data)
+    # drop tracking PK if duplicated positive indices exist
+    new_tracked_keys_zoom <- if (anyDuplicated(idx) && idx[1] > 0) discard(tracked_keys, tracked_keys == orig_pk) else tracked_keys
+    replace_zoomed_tbl(.data, slice(get_zoomed_tbl(.data), idx), new_tracked_keys_zoom)
+  } else replace_zoomed_tbl(.data, slice(get_zoomed_tbl(.data), idx))
 }
 
 #' @export

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -162,7 +162,7 @@ slice.zoomed_dm <- function(.data, idx) {
 
   if (!inherits(idx, "integer")) {
     # numeric vector only accepted if identical to itself as integer
-    if (inherits(idx, "numeric") && !all(as.integer(idx) == idx)) abort_need_int(class(idx))
+    if (!inherits(idx, "numeric") || inherits(idx, "numeric") && !all(as.integer(idx) == idx)) abort_need_int(class(idx))
   }
   # FIXME: will be easier if we have an extra row in `def` for the zoomed table
   if (cdm_has_pk(.data, !!orig_name_zoomed(.data))) {

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -162,7 +162,7 @@ slice.zoomed_dm <- function(.data, idx) {
 
   if (!inherits(idx, "integer")) {
     # numeric vector only accepted if identical to itself as integer
-    if (!inherits(idx, "numeric") || inherits(idx, "numeric") && !all(as.integer(idx) == idx)) abort_need_int(class(idx))
+    if (!inherits(idx, "numeric") || !all(as.integer(idx) == idx)) abort_need_int(class(idx))
   }
   # FIXME: will be easier if we have an extra row in `def` for the zoomed table
   if (cdm_has_pk(.data, !!orig_name_zoomed(.data))) {

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -158,6 +158,7 @@ slice.dm <- function(.data, ...) {
 
 #' @export
 slice.zoomed_dm <- function(.data, idx) {
+  if (is_missing(idx)) return(.data)
 
   if (!inherits(idx, "integer")) {
     # numeric vector only accepted if identical to itself as integer

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -576,15 +576,3 @@ abort_need_to_select_rhs_by <- function(y_name, rhs_by) {
 error_need_to_select_rhs_by <- function(y_name, rhs_by) {
   glue("You need to select by-column {tick(rhs_by)} of RHS-table {tick(y_name)}.")
 }
-
-
-# slice needs integers ----------------------------------------------------
-
-abort_need_int <- function(class) {
-  abort(error_need_int(class), .subclass = cdm_error_full("need_int"))
-}
-
-error_need_int <- function(class) {
-  glue("The method `slice.zoomed_dm()` only accepts `integer` (or `numeric` with `0` in all decimal places) ",
-       "vectors as an argument, not class: {commas(tick(class))}.")
-}

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -586,5 +586,5 @@ abort_need_int <- function(class) {
 
 error_need_int <- function(class) {
   glue("The method `slice.zoomed_dm()` only accepts `integer` (or `numeric` with `0` in all decimal places) ",
-       "vectors as an argument, not {commas(tick(class))}.")
+       "vectors as an argument, not class: {commas(tick(class))}.")
 }

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -576,3 +576,15 @@ abort_need_to_select_rhs_by <- function(y_name, rhs_by) {
 error_need_to_select_rhs_by <- function(y_name, rhs_by) {
   glue("You need to select by-column {tick(rhs_by)} of RHS-table {tick(y_name)}.")
 }
+
+
+# slice needs integers ----------------------------------------------------
+
+abort_need_int <- function(class) {
+  abort(error_need_int(class), .subclass = cdm_error_full("need_int"))
+}
+
+error_need_int <- function(class) {
+  glue("The method `slice.zoomed_dm()` only accepts `integer` (or `numeric` with `0` in all decimal places) ",
+       "vectors as an argument, not {commas(tick(class))}.")
+}

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -572,6 +572,22 @@ test_that("key tracking works", {
     tbl(dm_nycflights_small, "weather") %>% transmute(celsius_temp = (temp - 32) * 5/9)
   )
 
+  # slice retains all keys when no positive indices are duplicated
+  expect_identical(
+    zoomed_dm %>% slice(1:5) %>% cdm_update_zoomed_tbl() %>% get_all_keys("t2"),
+    get_all_keys(dm_for_filter, "t2")
+  )
+
+  expect_identical(
+    zoomed_dm %>% slice(rep(1:3, 2)) %>% cdm_update_zoomed_tbl() %>% get_all_keys("t2"),
+    set_names(c("d", "e"))
+  )
+
+  expect_identical(
+    zoomed_dm %>% slice(rep(-1:-3, 2)) %>% cdm_update_zoomed_tbl() %>% get_all_keys("t2"),
+    get_all_keys(dm_for_filter, "t2")
+  )
+
   # it should be possible to combine 'filter' on a zoomed_dm with all other dplyr-methods; example: 'rename'
   expect_equivalent_dm(
     cdm_zoom_to_tbl(dm_for_filter, t2) %>%

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -130,20 +130,29 @@ test_that("basic test: 'arrange()'-methods work", {
 })
 
 test_that("basic test: 'slice()'-methods work", {
-  expect_identical(
-    slice(zoomed_dm, 3:6) %>% get_zoomed_tbl(),
-    slice(t2, 3:6)
+  expect_message(
+    expect_identical(slice(zoomed_dm, 3:6) %>% get_zoomed_tbl(), slice(t2, 3:6)),
+    "`slice.zoomed_dm\\(\\)` can potentially"
   )
 
-  expect_cdm_error(
-    slice(zoomed_dm, t2),
-    "need_int"
+  # silent when no PK available
+  expect_silent(
+    expect_identical(
+      slice(cdm_zoom_to_tbl(dm_for_disambiguate, iris_3), 1:3) %>% get_zoomed_tbl(),
+      slice(iris_3, 1:3)
+    )
   )
 
-  expect_cdm_error(
-    slice(zoomed_dm, 1.1),
-    "need_int"
+  # silent when no PK available anymore
+  expect_silent(
+    mutate(zoomed_dm, c = 1) %>% slice(1:3)
   )
+
+  expect_silent(
+    expect_identical(
+      slice(zoomed_dm, if_else(d < 5, 1:6, 7:2), .keep_pk = FALSE) %>% get_zoomed_tbl(),
+      slice(t2, if_else(d < 5, 1:6, 7:2)))
+    )
 
   expect_cdm_error(
     slice(dm_for_filter, 2),
@@ -582,21 +591,9 @@ test_that("key tracking works", {
     tbl(dm_nycflights_small, "weather") %>% transmute(celsius_temp = (temp - 32) * 5/9)
   )
 
-  # slice retains all keys when no positive indices are duplicated
-  expect_identical(
-    zoomed_dm %>% slice(1:5) %>% cdm_update_zoomed_tbl() %>% get_all_keys("t2"),
-    get_all_keys(dm_for_filter, "t2")
-  )
-
-  expect_identical(
-    zoomed_dm %>% slice(rep(1:3, 2)) %>% cdm_update_zoomed_tbl() %>% get_all_keys("t2"),
-    set_names(c("d", "e"))
-  )
-
-  expect_identical(
-    zoomed_dm %>% slice(rep(-1:-3, 2)) %>% cdm_update_zoomed_tbl() %>% get_all_keys("t2"),
-    get_all_keys(dm_for_filter, "t2")
-  )
+  expect_identical(slice(zoomed_dm, if_else(d < 5, 1:6, 7:2), .keep_pk = FALSE) %>% get_tracked_keys(), set_names(c("d", "e")))
+  expect_identical(slice(zoomed_dm, if_else(d < 5, 1:6, 7:2)) %>% get_tracked_keys(), set_names(c("c", "d", "e")))
+  expect_identical(slice(zoomed_dm, if_else(d < 5, 1:6, 7:2), .keep_pk = TRUE) %>% get_tracked_keys(), set_names(c("c", "d", "e")))
 
   # it should be possible to combine 'filter' on a zoomed_dm with all other dplyr-methods; example: 'rename'
   expect_equivalent_dm(

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -136,6 +136,16 @@ test_that("basic test: 'slice()'-methods work", {
   )
 
   expect_cdm_error(
+    slice(zoomed_dm, t2),
+    "need_int"
+  )
+
+  expect_cdm_error(
+    slice(zoomed_dm, 1.1),
+    "need_int"
+  )
+
+  expect_cdm_error(
     slice(dm_for_filter, 2),
     "only_possible_w_zoom"
   )


### PR DESCRIPTION
- now drops potential primary key if positive indices are repeated
- now only accepts integer and numeric vectors without any decimal place different from `0`

fixes #151 