### PR TITLE
Small-ish bug in 'cdm_rm_pk()'

### DIFF
--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -161,18 +161,14 @@ cdm_rm_pk <- function(dm, table, rm_referencing_fks = FALSE) {
 
   def <- cdm_get_def(dm)
 
-  selected <- set_names(def$table)
-  selected <- selected[selected != table]
-  new_def <- filter_recode_table_fks(def, selected)
-
-  if (!rm_referencing_fks && !identical(def$fks, new_def$fks)) {
-    affected <- !map2_lgl(def$fks, new_def$fks, identical)
-    abort_first_rm_fks(table, def$table[affected])
+  if (!rm_referencing_fks && cdm_is_referenced(dm, !!table)) {
+    affected <- cdm_get_referencing_tables(dm, !!table)
+    abort_first_rm_fks(table, affected)
   }
+  def$pks[def$table == table] <- list(new_pk())
+  def$fks[def$table == table] <- list(new_fk())
 
-  new_def$pks[new_def$table == table] <- list(tibble(column = list()))
-
-  new_dm3(new_def)
+  new_dm3(def)
 }
 
 

--- a/tests/testthat/test-primary-keys.R
+++ b/tests/testthat/test-primary-keys.R
@@ -74,6 +74,19 @@ test_that("cdm_rm_pk() works as intended?", {
       class = "table_not_in_dm"
     )
   )
+
+  # test if error is thrown if FK points to PK that is about to be removed
+  expect_cdm_error(
+    cdm_rm_pk(dm_for_filter, t4),
+    "first_rm_fks"
+  )
+
+  # test logic if argument `rm_referencing_fks = TRUE`
+  expect_equivalent_dm(
+    cdm_rm_pk(dm_for_filter, t4, rm_referencing_fks = TRUE),
+    cdm_rm_fk(dm_for_filter, t5, l, t4) %>%
+      cdm_rm_pk(t4)
+  )
 })
 
 test_that("cdm_has_pk() works as intended?", {

--- a/tests/testthat/test-primary-keys.R
+++ b/tests/testthat/test-primary-keys.R
@@ -87,6 +87,13 @@ test_that("cdm_rm_pk() works as intended?", {
     cdm_rm_fk(dm_for_filter, t5, l, t4) %>%
       cdm_rm_pk(t4)
   )
+
+  expect_equivalent_dm(
+    cdm_rm_pk(dm_for_filter, t3, rm_referencing_fks = TRUE),
+    cdm_rm_fk(dm_for_filter, t4, j, t3) %>%
+      cdm_rm_fk(t2, e, t3) %>%
+      cdm_rm_pk(t3)
+  )
 })
 
 test_that("cdm_has_pk() works as intended?", {


### PR DESCRIPTION
Is currently like this on master:
``` r
suppressPackageStartupMessages({
  library(dm)
  library(tibble)
})
t3 = tibble(f = LETTERS[5:7], g = c("four", "five", "six"))
t4 = tibble(h = letters[3:5], i = c("five", "six", "seven"), j = c("E", "F", "F"))
t5 = tibble(
  k = 2:4,
  l = letters[3:5],
  m = c("tree", "streetlamp", "streetlamp")
)
test_dm <- dm(t3, t4, t5) %>% 
  cdm_add_pk(t4, h) %>% 
  cdm_add_pk(t3, f) %>% 
  cdm_add_fk(t5, l, t4) %>% 
  cdm_add_fk(t4, j, t3)
cdm_draw(test_dm)
```

![](https://i.imgur.com/W9N2j5i.png)

``` r

# this happens when removing referencing(!) keys
cdm_rm_pk(test_dm, t4, rm_referencing_fks =TRUE) %>% 
  cdm_draw
```

![](https://i.imgur.com/IUgPvI4.png)

<sup>Created on 2019-11-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
But should be like this (this branch):

``` r
suppressPackageStartupMessages({
  library(dm)
  library(tibble)
})
t3 = tibble(f = LETTERS[5:7], g = c("four", "five", "six"))
t4 = tibble(h = letters[3:5], i = c("five", "six", "seven"), j = c("E", "F", "F"))
t5 = tibble(
  k = 2:4,
  l = letters[3:5],
  m = c("tree", "streetlamp", "streetlamp")
)
test_dm <- dm(t3, t4, t5) %>% 
  cdm_add_pk(t4, h) %>% 
  cdm_add_pk(t3, f) %>% 
  cdm_add_fk(t5, l, t4) %>% 
  cdm_add_fk(t4, j, t3)
cdm_draw(test_dm)
```

![](https://i.imgur.com/x6fkZxR.png)

``` r

# this happens when removing referencing(!) keys
cdm_rm_pk(test_dm, t4, rm_referencing_fks =TRUE) %>% 
  cdm_draw
```

![](https://i.imgur.com/TUDFP3d.png)

<sup>Created on 2019-11-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>