### PR TITLE
Removed data_model components in vignettes (Issue #170)

### DIFF
--- a/vignettes/dm-class-and-basic-operations.Rmd
+++ b/vignettes/dm-class-and-basic-operations.Rmd
@@ -35,12 +35,12 @@ Let's take a look at the `dm` class.
 
 The `dm` class consists of a collection of tables and metadata about the tables, such as 
 
-- the names and physical locations of the tables
+- the names of the tables
 - the names of the columns of the tables
 - the primary and foreign keys of the tables to link the tables together
-- the number of rows in the tables
+- the data (either as data frames or as references to database tables)
 
-All tables in a `dm` must be obtained from the same data source, either the same database or a local data frame; 
+All tables in a `dm` must be obtained from the same data source;
 csv files and spreadsheets would need to be imported to data frames in R.
 
 

--- a/vignettes/dm-class-and-basic-operations.Rmd
+++ b/vignettes/dm-class-and-basic-operations.Rmd
@@ -27,30 +27,22 @@ knit_print.grViz <- function(x, ...) {
 }
 ```
 
-The goal of the {dm} package and the `dm` class that comes with it, is to make your life easier when you are dealing with data and data models.
+The goal of the {dm} package and the `dm` class that comes with it, is to make your life easier when you are dealing with data from several different tables.
 
 Let's take a look at the `dm` class.
 
 ## Class `dm`
 
-The `dm` class contains a set of tables, as well as information about their primary keys and the relations between the tables. 
-You can have your `dm` object based on different data sources, such as a local environment or a database.
+The `dm` class consists of a collection of tables and metadata about the tables, such as 
 
-`dm` is a wrapper around two classes that are independent from each other:
+- the names and physical locations of the tables
+- the names of the columns of the tables
+- the primary and foreign keys of the tables to link the tables together
+- the number of rows in the tables
 
-1. one part of the object is a [`src` object](https://dplyr.tidyverse.org/reference/src.html) from [{dplyr}](https://dplyr.tidyverse.org/)
-2. the other part is an object of the `data_model` class
- from the [{datamodelr}](https://github.com/bergant/datamodelr) package
+All tables in a `dm` must be obtained from the same data source, either the same database or a local data frame; 
+csv files and spreadsheets would need to be imported to data frames in R.
 
-The `src` object contains information about where the tables of your data model are physically stored. 
-The `data_model` object contains meta-information about your data, such as:
-
-- what the primary keys in your schema are
-- how the tables are related to each other, i.e. what the foreign key relations are
-
-Last but not least, the third part of the object is a named list that contains the tables on the `src`.
-
-So much about theory, let us now see how to construct such an object and how it looks like in `R`:
 
 ## Examples of `dm` objects {#ex_dm}
 
@@ -72,7 +64,7 @@ library(nycflights13)
 library(dm)
 empty_dm <- dm()
 empty_dm
-cdm_add_tbl(empty_dm, airlines, airports, flights, planes, weather)
+cdm_add_tbl(empty_dm, airlines, airports, flights, planes, weather) 
 ```
 
 ### Coerce a list of tables
@@ -105,20 +97,6 @@ iris_dm <- new_dm(list("iris1" = iris, "iris2" = iris))
 iris_dm
 ```
 
-<!-- And lastly, with `new_dm()` you can create a `dm` by providing the three individual parts that it consists of: -->
-<!-- ```{r} -->
-<!-- local_src <- src_df(env = new.env()) -->
-<!-- tables <- list("iris1" = iris, "iris2" = iris) -->
-<!-- data_model <- cdm_get_data_model(iris_dm) -->
-<!-- another_iris_dm <-  -->
-<!--   new_dm( -->
-<!--     tables = tables, -->
-<!--     data_model = data_model -->
-<!--     ) -->
-<!-- another_iris_dm -->
-<!-- ``` -->
-
-<!--You noticed above that by using the `cdm_get_data_model()` function, we were able to access the `data_model` part of a `dm`.-->
 
 We can get the list of tables with `cdm_get_tables()` and the `src` object with `cdm_get_src()`.
 
@@ -152,7 +130,7 @@ cdm_has_pk(flights_dm, airports)
 flights_dm_with_key <- cdm_add_pk(flights_dm, airports, faa)
 flights_dm_with_key
 ```
-The `dm` model now has a primary key. Let's check:
+The `dm` now has a primary key. Let's check:
 ```{r}
 cdm_has_pk(flights_dm_with_key, airports)
 ```
@@ -198,7 +176,7 @@ Useful functions for managing foreign key relations include:
 Now it gets (even more) interesting: we want to define relations between different tables.
 With the `cdm_add_fk()` function you can define which column of which table points to another table's column.
 
-When dealing with data models, a foreign key from one table has to always point to a primary key of another table.
+This is done by choosing a foreign key from one table that will point to a primary key of another table.
 The primary key of the referred table must be set with `cdm_add_pk()`.
 `cdm_add_fk()` will find the primary key column of the referenced table by itself and make the indicated column of the child table point to it.
 
@@ -217,7 +195,7 @@ What if we tried to add another foreign key relation from `flights` to `airports
 ```{r error=TRUE}
 flights_dm_with_fk %>% cdm_add_fk(flights, dest, airports, check = TRUE)
 ```
-As you can see, behind the scenes, checks are executed automatically (unless `check = FALSE`) by the functions of `dm` to prevent steps that do not comply with the logic of data models.
+As you can see, behind the scenes, checks are executed automatically (unless `check = FALSE`) by the functions of `dm` to prevent steps that would result in inconsistent representations.
 
 Use `cdm_has_fk()` for checking if a foreign key exists that is pointing from one table to another:
 ```{r}
@@ -242,7 +220,7 @@ flights_dm_with_fk %>%
 flights_dm_with_fk %>% 
   cdm_rm_fk(flights, NULL, airports) %>% 
   cdm_get_fk(flights, airports)
-```
+``` 
 
 Since the primary keys are defined in the `dm` object, you do not need to provide the referenced column name of `ref_table`.
 This is always the primary key column of the table.
@@ -253,7 +231,7 @@ Another function for getting to know your data better (cf. `cdm_enum_pk_candidat
 cdm_enum_fk_candidates(flights_dm_with_key, weather, airports)
 ```
 
-Get an overview of all foreign key relations in your data model with`cdm_get_all_fks()`:
+Get an overview of all foreign key relations with`cdm_get_all_fks()`:
 
 ```{r}
 cdm_get_all_fks(cdm_nycflights13(cycle = TRUE))

--- a/vignettes/dm-filtering.Rmd
+++ b/vignettes/dm-filtering.Rmd
@@ -60,7 +60,7 @@ See `vignette("dm-setup")` for details.
 dm <- cdm_nycflights13()
 ```
 
-The console output of the 'dm` object shows its data and metadata, and is colored for a clarity:
+The console output of the 'dm` object shows its data and metadata, and is colored for clarity:
 
 ```{r}
 dm

--- a/vignettes/dm-filtering.Rmd
+++ b/vignettes/dm-filtering.Rmd
@@ -54,6 +54,7 @@ The built-in `dm::cdm_nycflights13()` function takes care of this.
 A [data model object](https://krlmlr.github.io/dm/articles/dm-class-and-basic-operations.html#class-dm) contains data from the source tables, and metadata about the tables.
 
 If you would like to create a `dm` object from tables other than the example data, you can use the `new_dm()`, `dm()` or `as_dm()` functions.
+See `vignette("dm-setup")` for details.
 
 ```{r}
 dm <- cdm_nycflights13()

--- a/vignettes/dm-filtering.Rmd
+++ b/vignettes/dm-filtering.Rmd
@@ -51,21 +51,15 @@ The data comes from the US Bureau of Transportation Statistics, and is documente
 To start with our exploration, we have to create a `dm` object from the {nycflights13} data.
 The built-in `dm::cdm_nycflights13()` function takes care of this.
 
-A [data model object](https://krlmlr.github.io/dm/articles/dm-class-and-basic-operations.html#class-dm) contains both data and metadata.
+A [data model object](https://krlmlr.github.io/dm/articles/dm-class-and-basic-operations.html#class-dm) contains data from the source tables, and metadata about the tables.
 
-If you would like to create a `dm` from other tables, you can use the `new_dm()`, `dm()` or `as_dm()` functions.
+If you would like to create a `dm` object from tables other than the example data, you can use the `new_dm()`, `dm()` or `as_dm()` functions.
 
 ```{r}
 dm <- cdm_nycflights13()
 ```
 
-A `dm` object output with data and metadata consists of three elements: 
-
-1. the table sources
-2. the data model
-3. a review of active filter conditions
-
-The console output is colored for a clear output:
+The console output of the 'dm` object shows its data and metadata, and is colored for a clarity:
 
 ```{r}
 dm

--- a/vignettes/dm-introduction-relational-data-models.Rmd
+++ b/vignettes/dm-introduction-relational-data-models.Rmd
@@ -100,7 +100,7 @@ dm %>%
 ```
 
 The `flights` table is linked to three other tables: `airlines`, `planes` and `airports`.
-By using directed arrows, the visualization explicitly shows the connection between different columns (they are called attributes in the relational data sphere).
+By using directed arrows, the visualization shows explicitly the connection between different columns (they are called attributes in the relational data sphere).
 
 For example: The column `carrier` in `flights` can be joined with the column `carrier` from the `airlines` table.
 

--- a/vignettes/dm-visualization.Rmd
+++ b/vignettes/dm-visualization.Rmd
@@ -26,9 +26,8 @@ knit_print.grViz <- function(x, ...) {
 }
 ```
 
-
 Once you have all your primary keys set and all foreign key relations defined, a graphical representation of your data model offers a condensed view of the tables and the relationships between the tables.
-The following functions can be used to visualize the data model of a `dm` object:^[The functions in this section rely heavily on related functions of [{datamodelr}](https://github.com/bergant/datamodelr).]
+The following functions can be used to visualize the `dm` object:^[The functions in this section rely heavily on related functions of [{datamodelr}](https://github.com/bergant/datamodelr).]
 
 1. `cdm_draw()`
 1. `cdm_set_colors()`
@@ -57,7 +56,7 @@ cdm_get_available_colors()
 Colors are assigned with `cdm_set_colors()` using syntax that is similar to `switch()`.
 Any table to which you do not specifically assign a color will not be altered. 
 The result of `cdm_set_colors()` is a `dm` object.
-The information about the color is stored in its `data_model`-part.
+The information about the color is stored together with the rest of the metadata.
 ```{r}
 flights_dm_w_many_keys_and_colors <-
   flights_dm_w_many_keys %>% 
@@ -88,7 +87,7 @@ flights_dm_w_many_keys_and_colors %>%
   cdm_draw(view_type = "title_only")
 ```
 
-If you would like to see only a subset of the whole data model, use `cdm_select_tbl()` before drawing:
+If you would like to visualize only a some of the tables, use `cdm_select_tbl()` before drawing:
 
 ```{r}
 flights_dm_w_many_keys_and_colors %>% 

--- a/vignettes/dm-visualization.Rmd
+++ b/vignettes/dm-visualization.Rmd
@@ -27,7 +27,7 @@ knit_print.grViz <- function(x, ...) {
 ```
 
 Once you have all your primary keys set and all foreign key relations defined, a graphical representation of your data model offers a condensed view of the tables and the relationships between the tables.
-The following functions can be used to visualize the `dm` object:^[The functions in this section rely heavily on related functions of [{datamodelr}](https://github.com/bergant/datamodelr).]
+The following functions can be used to visualize the `dm` object:^[The code for the functions in this section is borrowed from the [{datamodelr}](https://github.com/bergant/datamodelr) package.]
 
 1. `cdm_draw()`
 1. `cdm_set_colors()`

--- a/vignettes/dm.Rmd
+++ b/vignettes/dm.Rmd
@@ -30,10 +30,10 @@ The goal of the package {dm} and its `dm` class is to facilitate working with mu
 
 An object of the `dm` class contains the data in the tables, and metadata about the tables, such as
 
-- the names and physical locations of the tables (a database, or a data frame in your R session)
+- the names of the tables
 - the names of the columns of the tables
 - the key constraints to link the tables together
-- the number of rows in the tables
+- the data (either as data frames or as references to database tables)
 
 This package augments [{dplyr}](https://dplyr.tidyverse.org/)/[{dbplyr}](https://dbplyr.tidyverse.org/) workflows:
 

--- a/vignettes/dm.Rmd
+++ b/vignettes/dm.Rmd
@@ -26,17 +26,19 @@ knit_print.grViz <- function(x, ...) {
 }
 ```
 
-The goal of the package {dm} and its `dm` class is to facilitate work with multiple related tables.
-An object of the `dm` class contains all relevant information about the tables in a data model:
+The goal of the package {dm} and its `dm` class is to facilitate working with multiple related tables.
 
-1. the place where the tables live (i.e., the `src`: a database (DB) or locally in your R session)
-1. the metadata from the data model: the tables, columns and key constraints
-1. the data in the tables
+An object of the `dm` class contains the data in the tables, and metadata about the tables, such as
+
+- the names and physical locations of the tables (a database, or a data frame in your R session)
+- the names of the columns of the tables
+- the key constraints to link the tables together
+- the number of rows in the tables
 
 This package augments [{dplyr}](https://dplyr.tidyverse.org/)/[{dbplyr}](https://dbplyr.tidyverse.org/) workflows:
 
 - multiple related tables are kept in a single compound object
-- joins across multiple tables are available by specifying the tables involved, no need to memorize column names or relationships
+- joins across multiple tables are available by specifying the tables involved, without a need to memorize column names or relationships
 
 In addition, a battery of utilities is provided that helps with creating a tidy data model.
 
@@ -74,7 +76,7 @@ flights_dm <- dm_from_src(src_df(pkg = "nycflights13"))
 flights_dm
 ```
 
-This fairly verbose output shows the three components of a `dm` object: the table source, the metadata, and row counts.
+This fairly verbose output shows the data and metadata of a `dm` object.
 These components can be accessed with `cdm_get_src()` and `cdm_get_tables()`.
 
 ```{r}
@@ -87,7 +89,7 @@ cdm_get_all_fks(flights_dm)
 
 ## Keys and visualization {#keys}
 
-As you can see in the "Data model" part of the output above, no keys have been set so far.
+As you can see in the output above, no keys have been set so far.
 We will use `cdm_add_pk()` and `cdm_add_fk()` to add primary keys (pk) and foreign keys (fk):
 
 ```{r}


### PR DESCRIPTION
Two code examples throw an error (could not find function "dm_from_src") when knitting the vignettes that contain them.

Please suggest a fix for the error and review my changes.

Closes #170.