### PR TITLE
test for cycle in 'get_all_filtered_connected()'

### DIFF
--- a/R/filter-dm.R
+++ b/R/filter-dm.R
@@ -173,7 +173,7 @@ get_all_filtered_connected <- function(dm, table) {
     tibble(
       node = names(V(graph)),
       parent = names(paths$predecessors),
-      # both `graph` and `paths` are based on order of `finite_distances`,
+      # all of `graph`, `paths` and `finite_distances` are based on the same subset of tables,
       # hence the resulting tibble is correct
       distance = finite_distances
     )

--- a/R/graph.R
+++ b/R/graph.R
@@ -12,11 +12,6 @@ cdm_is_referenced <- function(dm, table) {
   has_length(cdm_get_referencing_tables(dm, !!ensym(table)))
 }
 
-is_referenced_data_model <- function(data_model, table_name) {
-  which_ind <- data_model$references$ref == table_name
-  any(which_ind)
-}
-
 #' Get the names of the tables of a [`dm`] that reference a given table.
 #'
 #' @inheritParams cdm_is_referenced
@@ -34,35 +29,6 @@ cdm_get_referencing_tables <- function(dm, table) {
   def <- cdm_get_def(dm)
   i <- which(def$table == table)
   def$fks[[i]]$table
-}
-
-calculate_join_list <- function(dm, table_name) {
-  g <- create_graph_from_dm(dm)
-
-  if (!table_name %in% names(V(g))) {
-    return(tibble(
-      lhs = character(), rhs = character(), rank = integer(), has_father = logical()
-    ))
-  }
-
-  bfs <- igraph::bfs(g, table_name, father = TRUE, rank = TRUE, unreachable = FALSE)
-
-  nodes <- names(V(g))
-
-  has_father <- !is.na(bfs$father)
-
-  res <-
-    tibble(lhs = nodes, rhs = nodes[bfs$father], rank = bfs$rank, has_father) %>%
-    filter(has_father) %>%
-    arrange(rank)
-
-  subgraph_nodes <- union(res$lhs, res$rhs)
-  subgraph <- igraph::induced_subgraph(g, subgraph_nodes)
-  if (length(V(subgraph)) - 1 < length(E(subgraph))) {
-    abort_no_cycles()
-  }
-
-  res
 }
 
 create_graph_from_dm <- function(dm, directed = FALSE) {

--- a/tests/testthat/test-filter-dm.R
+++ b/tests/testthat/test-filter-dm.R
@@ -52,6 +52,19 @@ test_that("get_all_filtered_connected() calculates the paths correctly", {
   expect_pred_chain(fc_t4, c("t4_2", "t5", "t4"))
   expect_pred_chain(fc_t4, c("t6", "t5", "t4"))
   expect_not_pred(fc_t4, c("t6_2", "t3", "t2", "t1"))
+
+  # fails when cycle is present
+  expect_cdm_error(
+    dm_for_filter_w_cycle %>% cdm_filter(t1, a > 3) %>% cdm_get_filtered_table("t3"),
+    "no_cycles"
+  )
+
+  # FIXME: fails, when it could actually work (check diagram of `dm_for_filter_w_cycle`)
+  # expect_identical(
+  #   dm_for_filter_w_cycle %>% cdm_filter(t1, a > 3) %>% cdm_get_filtered_table("t2"),
+  #   semi_join(t2, filter(t1, a > 3))
+  # )
+
 })
 
 

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -275,6 +275,14 @@ test_that("`cdm_flatten_to_tbl()` does the right things for 'right_join()'", {
     cdm_flatten_to_tbl(bad_filtered_dm, tbl_1, join = right_join),
     class = c("apply_filters_first_right_join", "apply_filters_first")
   )
+
+  # fails when there is a cycle
+  expect_cdm_error(
+    dm_nycflights_small %>%
+      cdm_add_fk(flights, origin, airports) %>%
+      cdm_flatten_to_tbl(flights),
+    "no_cycles"
+    )
 })
 
 test_that("`cdm_squash_to_tbl()` does the right things", {
@@ -324,6 +332,12 @@ test_that("`cdm_squash_to_tbl()` does the right things", {
   expect_cdm_error(
     cdm_squash_to_tbl(dm_more_complex, t5, t4, t3, join = anti_join),
     class = "squash_limited"
+  )
+
+  # fails when there is a cycle:
+  expect_cdm_error(
+    cdm_squash_to_tbl(dm_for_filter_w_cycle, t5),
+    "no_cycles"
   )
 })
 

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -15,21 +15,6 @@ test_that("functions working with graphs do the right thing?", {
     "t6", "t5",     6,        TRUE
   )
 
-  expect_equivalent(
-    calculate_join_list(dm_for_filter, "t1"),
-    join_list_tbl_1
-  )
-
-  expect_equivalent(
-    calculate_join_list(dm_for_filter, "t3"),
-    join_list_tbl_3
-  )
-
-  expect_cdm_error(
-    calculate_join_list(dm_for_filter_w_cycle, "t3"),
-    class = "no_cycles"
-  )
-
   expect_identical_graph(
     igraph::graph_from_data_frame(
       tibble(


### PR DESCRIPTION
For the test we check in an induced subgraph of all connected tables/nodes (related to one "start" table) if `N(E(graph)) >= N(V(graph))`

The only problem is, that we are sometimes too strict: assume a graph `(t1 - t2, t2 - t3, t3 - t4, t4 - t2)` and we filter `t1` and we request `t2`, then it fails cause the subgraph consists of `(t1, t2, t3, t4)`. But, if we want to resolve this properly, we might need to work with something like `igraph::all_simple_paths()` for many pairs of tables, which would slow down things quite a bit. So I tend to think, that this solution here is not so bad.

Tests are included in this PR.

addresses 2nd part of issue #150 