### PR TITLE
Improve error messages for missing tables

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -258,6 +258,7 @@ anti_join.zoomed_dm <- function(x, y, by = NULL, copy = NULL, suffix = NULL, sel
 
 prepare_join <- function(x, y, by, selected, suffix, copy, disambiguate = TRUE) {
   y_name <- as_string(ensym(y))
+  check_correct_input(x, y_name)
   select_quo <- enquo(selected)
 
   if (!is_null(suffix)) message("Column names are disambiguated if necessary, `suffix` ignored.")

--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -45,7 +45,7 @@ abort_table_not_in_dm <- function(table_name, dm_tables) {
 }
 
 error_txt_table_not_in_dm <- function(table_name, dm_tables) {
-  glue("Tables {commas(tick(table_name))} not in `dm` object. Available table names: {commas(tick(dm_tables))}")
+  glue("Table(s) {commas(tick(table_name))} not in `dm` object. Available table names: {commas(tick(dm_tables))}")
 }
 
 # error: is not subset of -------------------------------------------------

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -177,6 +177,7 @@ dm_join_to_tbl <- function(dm, table_1, table_2, join = left_join) {
 
   t1_name <- as_string(ensym(table_1))
   t2_name <- as_string(ensym(table_2))
+  check_correct_input(dm, c(t1_name, t2_name), 2L)
 
   rel <- parent_child_table(dm, {{ table_1 }}, {{ table_2 }})
   start <- rel$child_table

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -22,13 +22,11 @@
 #' @export
 dm_add_fk <- nse(function(dm, table, column, ref_table, check = FALSE) {
   table_name <- as_name(ensym(table))
-  check_correct_input(dm, table_name)
+  ref_table_name <- as_name(ensym(ref_table))
+  check_correct_input(dm, c(table_name, ref_table_name), 2L)
 
   column_name <- as_name(ensym(column))
   check_col_input(dm, table_name, column_name)
-
-  ref_table_name <- as_name(ensym(ref_table))
-  check_correct_input(dm, ref_table_name)
 
   ref_column_name <- dm_get_pk(dm, !!ref_table_name)
   if (is_empty(ref_column_name)) {
@@ -95,8 +93,7 @@ dm_get_fk <- function(dm, table, ref_table) {
   table_name <- as_name(ensym(table))
   ref_table_name <- as_name(ensym(ref_table))
 
-  check_correct_input(dm, table_name)
-  check_correct_input(dm, ref_table_name)
+  check_correct_input(dm, c(table_name, ref_table_name), 2L)
 
   fks <- dm_get_data_model_fks(dm)
   fks$column[fks$table == table_name & fks$ref == ref_table_name]
@@ -149,13 +146,12 @@ dm_get_all_fks <- nse(function(dm) {
 #' )
 #' @export
 dm_rm_fk <- function(dm, table, column, ref_table) {
-  table <- as_name(ensym(table))
-  ref_table <- as_name(ensym(ref_table))
+  table_name <- as_name(ensym(table))
+  ref_table_name <- as_name(ensym(ref_table))
 
-  check_correct_input(dm, table)
-  check_correct_input(dm, ref_table)
+  check_correct_input(dm, c(table_name, ref_table_name), 2L)
 
-  fk_cols <- dm_get_fk(dm, !!table, !!ref_table)
+  fk_cols <- dm_get_fk(dm, !!table_name, !!ref_table_name)
   if (is_empty(fk_cols)) {
     return(dm)
   }
@@ -172,7 +168,7 @@ dm_rm_fk <- function(dm, table, column, ref_table) {
     # FIXME: Add tidyselect support
     cols <- as_name(ensym(column))
     if (!all(cols %in% fk_cols)) {
-      abort_is_not_fkc(table, cols, ref_table, fk_cols)
+      abort_is_not_fkc(table_name, cols, ref_table_name, fk_cols)
     }
   }
 
@@ -180,10 +176,10 @@ dm_rm_fk <- function(dm, table, column, ref_table) {
   cols <- as.list(cols)
 
   def <- dm_get_def(dm)
-  i <- which(def$table == ref_table)
+  i <- which(def$table == ref_table_name)
 
   fks <- def$fks[[i]]
-  fks <- fks[fks$table != table | is.na(vctrs::vec_match(fks$column, cols)), ]
+  fks <- fks[fks$table != table_name | is.na(vctrs::vec_match(fks$column, cols)), ]
   def$fks[[i]] <- fks
 
   new_dm3(def)
@@ -229,8 +225,7 @@ dm_enum_fk_candidates <- nse(function(dm, table, ref_table) {
   table_name <- as_string(ensym(table))
   ref_table_name <- as_string(ensym(ref_table))
 
-  check_correct_input(dm, table_name)
-  check_correct_input(dm, ref_table_name)
+  check_correct_input(dm, c(table_name, ref_table_name), 2L)
 
   ref_tbl_pk <- dm_get_pk(dm, !!ref_table_name)
 

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -166,17 +166,17 @@ dm_get_all_pks <- nse(function(dm) {
 #'   dm_has_pk(planes)
 #' @export
 dm_rm_pk <- function(dm, table, rm_referencing_fks = FALSE) {
-  table <- as_name(ensym(table))
-  check_correct_input(dm, table)
+  table_name <- as_name(ensym(table))
+  check_correct_input(dm, table_name)
 
   def <- dm_get_def(dm)
 
-  if (!rm_referencing_fks && dm_is_referenced(dm, !!table)) {
-    affected <- dm_get_referencing_tables(dm, !!table)
-    abort_first_rm_fks(table, affected)
+  if (!rm_referencing_fks && dm_is_referenced(dm, !!table_name)) {
+    affected <- dm_get_referencing_tables(dm, !!table_name)
+    abort_first_rm_fks(table_name, affected)
   }
-  def$pks[def$table == table] <- list(new_pk())
-  def$fks[def$table == table] <- list(new_fk())
+  def$pks[def$table == table_name] <- list(new_pk())
+  def$fks[def$table == table_name] <- list(new_fk())
 
   new_dm3(def)
 }

--- a/R/select-tbl.R
+++ b/R/select-tbl.R
@@ -43,10 +43,6 @@ dm_rename_tbl <- function(dm, ...) {
   dm_select_tbl_impl(dm, selected)
 }
 
-tidyrename_dm <- function(dm, ...) {
-  tidyselect::vars_rename(tidyselect_table_names(dm), ...)
-}
-
 tidyselect_table_names <- function(dm) {
   structure(
     src_tbls(dm),

--- a/R/test-dm.R
+++ b/R/test-dm.R
@@ -81,7 +81,7 @@ check_colnames <- function(key_tibble, dm_col_names, which) {
   if (!all(map2_lgl(key_tibble$table, key_tibble$column, ~ {
     ..2 %in% dm_col_names[[..1]]
   }))) {
-    abort_dm_invalid(glue("At least one {which} column name(s) not in `dm` tables' column names."))
+    abort_dm_invalid(glue("At least one {which} column name not in `dm` tables' column names."))
   }
 }
 

--- a/tests/testthat/out/error-msgs.txt
+++ b/tests/testthat/out/error-msgs.txt
@@ -9,7 +9,7 @@
 
 > error_txt_table_not_in_dm(c("laziness", "daydreaming"), c("hard_work", "focus",
 +   "overhours"))
-Tables `laziness`, `daydreaming` not in `dm` object. Available table names: `hard_work`, `focus`, `overhours`
+Table(s) `laziness`, `daydreaming` not in `dm` object. Available table names: `hard_work`, `focus`, `overhours`
 
 > error_txt_not_subset_of("playing", "game", "hunting", "game")
 Column `game` of table `playing` contains values (see above) that are not present in column `game` of table `hunting`

--- a/tests/testthat/test-dm-dplyr.R
+++ b/tests/testthat/test-dm-dplyr.R
@@ -275,6 +275,11 @@ test_that("basic test: 'join()'-methods for `dm` throws error", {
     right_join(dm_for_filter),
     "only_possible_w_zoom"
   )
+
+  expect_dm_error(
+    inner_join(dm_zoom_to_tbl(dm_for_filter, t1), t7),
+    "table_not_in_dm"
+  )
 })
 
 

--- a/tests/testthat/test-dm-flatten.R
+++ b/tests/testthat/test-dm-flatten.R
@@ -433,4 +433,9 @@ test_that("`dm_join_to_tbl()` works", {
       by = c("dim_3_key" = "dim_3_pk")
     )
   )
+
+  expect_dm_error(
+    dm_join_to_tbl(dm_for_filter, t7, t8),
+    "table_not_in_dm"
+  )
 })


### PR DESCRIPTION
- tweaking error issuing and messages

closes #220 

At the time of the PR there is still some inexplicable difference between `dm_select_tbl()` and `dm_rename_tbl()` which could be fixed by a hack, but IMO there should be an easier solution:
``` r
suppressPackageStartupMessages(library(dm))
dm_flights <- dm_nycflights13()

# this is as expected:
dm_select_tbl(dm_flights, f = mtcars)
#> Error: `mtcars` must evaluate to table positions or names, not a list. Available tables in `dm`: `airlines`, `airports`, `flights`, `planes`, `weather`

# this is strange:
dm_rename_tbl(dm_flights, f = mtcars)
#> Error: `f` = structure(list(mpg = c(21, 21, 22.8, 21.4, 18.7, 18.1, 14.3, 
#> 24.4, 22.8, 19.2, 17.8, 16.4, 17.3, 15.2, 10.4, 10.4, 14.7, 32.4, 
#> 30.4, 33.9, 21.5, 15.5, 15.2, 13.3, 19.2, 27.3, 26, 30.4, 15.8, 
#> 19.7, 15, 21.4), cyl = c(6, 6, 4, 6, 8, 6, 8, 4, 4, 6, 6, 8, 
#> 8, 8, 8, 8, 8, 4, 4, 4, 4, 8, 8, 8, 8, 4, 4, 4, 8, 6, 8, 4), 
#>     disp = c(160, 160, 108, 258, 360, 225, 360, 146.7, 140.8, 
#>     167.6, 167.6, 275.8, 275.8, 275.8, 472, 460, 440, 78.7, 75.7, 
#>     71.1, 120.1, 318, 304, 350, 400, 79, 120.3, 95.1, 351, 145, 
#>     301, 121), hp = c(110, 110, 93, 110, 175, 105, 245, 62, 95, 
#>     123, 123, 180, 180, 180, 205, 215, 230, 66, 52, 65, 97, 150, 
#>     150, 245, 175, 66, 91, 113, 264, 175, 335, 109), drat = c(3.9, 
#>     3.9, 3.85, 3.08, 3.15, 2.76, 3.21, 3.69, 3.92, 3.92, 3.92, 
#>     3.07, 3.07, 3.07, 2.93, 3, 3.23, 4.08, 4.93, 4.22, 3.7, 2.76, 
#>     3.15, 3.73, 3.08, 4.08, 4.43, 3.77, 4.22, 3.62, 3.54, 4.11
#>     ), wt = c(2.62, 2.875, 2.32, 3.215, 3.44, 3.46, 3.57, 3.19, 
#>     3.15, 3.44, 3.44, 4.07, 3.73, 3.78, 5.25, 5.424, 5.345, 2.2, 
#>     1.615, 1.835, 2.465, 3.52, 3.435, 3.84, 3.845, 1.935, 2.14, 
#>     1.513, 3.17, 2.77, 3.57, 2.78), qsec = c(16.46, 17.02, 18.61, 
#>     19.44, 17.02, 20.22, 15.84, 20, 22.9, 18.3, 18.9, 17.4, 17.6, 
#>     18, 17.98, 17.82, 17.42, 19.47, 18.52, 19.9, 20.01, 16.87, 
#>     17.3, 15.41, 17.05, 18.9, 16.7, 16.9, 14.5, 15.5, 14.6, 18.6
#>     ), vs = c(0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 
#>     0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1), am = c(1, 
#>     1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 
#>     0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1), gear = c(4, 4, 4, 3, 
#>     3, 3, 3, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 4, 4, 4, 3, 3, 3, 
#>     3, 3, 4, 5, 5, 5, 5, 5, 4), carb = c(4, 4, 1, 1, 2, 1, 4, 
#>     2, 2, 4, 4, 3, 3, 3, 4, 4, 4, 1, 2, 1, 1, 2, 2, 4, 2, 1, 
#>     2, 2, 4, 6, 8, 2)), row.names = c("Mazda RX4", "Mazda RX4 Wag", 
#> "Datsun 710", "Hornet 4 Drive", "Hornet Sportabout", "Valiant", 
#> "Duster 360", "Merc 240D", "Merc 230", "Merc 280", "Merc 280C", 
#> "Merc 450SE", "Merc 450SL", "Merc 450SLC", "Cadillac Fleetwood", 
#> "Lincoln Continental", "Chrysler Imperial", "Fiat 128", "Honda Civic", 
#> "Toyota Corolla", "Toyota Corona", "Dodge Challenger", "AMC Javelin", 
#> "Camaro Z28", "Pontiac Firebird", "Fiat X1-9", "Porsche 914-2", 
#> "Lotus Europa", "Ford Pantera L", "Ferrari Dino", "Maserati Bora", 
#> "Volvo 142E"), class = "data.frame") must be a table name or position, not a list. Available tables in `dm`: `airlines`, `airports`, `flights`, `planes`, `weather`
```

<sup>Created on 2019-12-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Only difference is, that `dm_rename_tbl()` uses `dm_try_tables(tidyselect::vars_rename(vars, ...), vars)` and `dm_select_tbl()` uses
`dm_try_tables(tidyselect::vars_select(vars, ...), vars)`