### PR TITLE
WIP: list for PK and FK cols

### DIFF
--- a/R/db-helpers.R
+++ b/R/db-helpers.R
@@ -15,7 +15,6 @@ systime_convenient <- function() {
 
 # Internal copy helper functions
 build_copy_data <- nse(function(dm, dest, table_names, unique_table_names) {
-
   source <-
     dm %>%
     dm_apply_filters() %>%

--- a/R/db-helpers.R
+++ b/R/db-helpers.R
@@ -15,6 +15,7 @@ systime_convenient <- function() {
 
 # Internal copy helper functions
 build_copy_data <- nse(function(dm, dest, table_names, unique_table_names) {
+
   source <-
     dm %>%
     dm_apply_filters() %>%
@@ -41,11 +42,19 @@ build_copy_data <- nse(function(dm, dest, table_names, unique_table_names) {
 
     pks <-
       dm_get_all_pks(dm) %>%
-      transmute(source_name = table, column = pk_col, pk = TRUE)
+      transmute(source_name = table, column = pk_col, pk = TRUE) %>%
+      # FIXME: this needs to be revisited once we have compound keys
+      unnest(column) %>%
+      # FIXME: this is needed, in case of empty tibble when class of `column` cannot be determined
+      mutate(column = as.character(column))
 
     fks <-
       dm_get_all_fks(dm) %>%
-      transmute(source_name = child_table, column = child_fk_col, fk = TRUE)
+      transmute(source_name = child_table, column = child_fk_col, fk = TRUE) %>%
+      # FIXME: this needs to be revisited once we have compound keys
+      unnest(column) %>%
+      # FIXME: this is needed, in case of empty tibble when class of `column` cannot be determined
+      mutate(column = as.character(column))
 
     # Need to supply NOT NULL modifiers for primary keys
     # because they are difficult to add to MSSQL after the fact

--- a/R/dm.R
+++ b/R/dm.R
@@ -372,11 +372,13 @@ dm_get_data_model_fks <- function(x, legacy = FALSE) {
 
   if (legacy) {
     mutate(all_fks,
-           # This is expected to break with compound keys
-           column = flatten_chr(column),
-           ref_col = flatten_chr(ref_col))
-    } else all_fks
-
+      # This is expected to break with compound keys
+      column = flatten_chr(column),
+      ref_col = flatten_chr(ref_col)
+    )
+  } else {
+    all_fks
+  }
 }
 
 #' Get filter expressions

--- a/R/dm.R
+++ b/R/dm.R
@@ -360,8 +360,8 @@ dm_get_data_model_fks <- function(x, legacy = FALSE) {
 
   if (nrow(fk_df) == 0) {
     return(tibble(
-      table = character(), column = character(),
-      ref = character(), ref_col = character()
+      table = character(), column = list(),
+      ref = character(), ref_col = list()
     ))
   }
   all_fks <-

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -134,10 +134,10 @@ dm_get_all_fks <- nse(function(dm) {
   dm_get_all_fks_impl(dm)
 })
 
-dm_get_all_fks_impl <- function(dm) {
-  dm_get_data_model_fks(dm) %>%
+dm_get_all_fks_impl <- function(dm, legacy = FALSE) {
+  dm_get_data_model_fks(dm, legacy) %>%
     select(child_table = table, child_fk_col = column, parent_table = ref) %>%
-    arrange(child_table, child_fk_col)
+    arrange(child_table)
 }
 
 #' Remove the reference(s) from one [`dm`] table to another

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -143,8 +143,8 @@ dm_get_all_pks <- nse(function(dm) {
   dm_get_all_pks_impl(dm)
 })
 
-dm_get_all_pks_impl <- function(dm) {
-  dm_get_data_model_pks(dm) %>%
+dm_get_all_pks_impl <- function(dm, legacy = FALSE) {
+  dm_get_data_model_pks(dm, legacy) %>%
     select(table = table, pk_col = column)
 }
 

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -9,8 +9,14 @@ expect_equivalent_dm <- function(dm1, dm2) {
   expect_identical(names(tables1), names(tables2))
   walk2(tables1, tables2, expect_equal)
 
-  expect_equal(dm_get_all_pks_impl(dm1), dm_get_all_pks_impl(dm2))
-  expect_equal(dm_get_all_fks_impl(dm1), dm_get_all_fks_impl(dm2))
+  expect_equal(
+    unnest(dm_get_all_pks_impl(dm1), pk_col),
+    unnest(dm_get_all_pks_impl(dm2), pk_col)
+    )
+  expect_equal(
+    unnest(dm_get_all_fks_impl(dm1), child_fk_col),
+    unnest(dm_get_all_fks_impl(dm2), child_fk_col)
+    )
 }
 
 expect_dm_error <- function(expr, class) {

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -12,11 +12,11 @@ expect_equivalent_dm <- function(dm1, dm2) {
   expect_equal(
     unnest(dm_get_all_pks_impl(dm1), pk_col),
     unnest(dm_get_all_pks_impl(dm2), pk_col)
-    )
+  )
   expect_equal(
     unnest(dm_get_all_fks_impl(dm1), child_fk_col),
     unnest(dm_get_all_fks_impl(dm2), child_fk_col)
-    )
+  )
 }
 
 expect_dm_error <- function(expr, class) {


### PR DESCRIPTION
As it turns out, the assumption of single key columns is rather deeply rooted in the code. So far the function `dm_examine_constraints()` works as it should, but tests fail, since helper functions have been adapted, which now produce the wrong type for key-column -info-tibbles.

TBC

closes #239