### PR TITLE
better zoomed tracking

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -146,7 +146,7 @@ new_dm <- function(tables = list()) {
   data <- unname(tables)
   table <- names2(tables)
   zoom <- new_zoom()
-  key_tracker_zoom <- new_key_tracker_zoom()
+  col_tracker_zoom <- new_col_tracker_zoom()
 
   pks <-
     tibble(
@@ -172,7 +172,7 @@ new_dm <- function(tables = list()) {
     left_join(fks, by = "table") %>%
     left_join(filters, by = "table") %>%
     left_join(zoom, by = "table") %>%
-    left_join(key_tracker_zoom, by = "table")
+    left_join(col_tracker_zoom, by = "table")
 
   new_dm3(def)
 }
@@ -208,8 +208,8 @@ new_zoom <- function() {
   tibble(table = character(), zoom = list())
 }
 
-new_key_tracker_zoom <- function() {
-  tibble(table = character(), key_tracker_zoom = list())
+new_col_tracker_zoom <- function() {
+  tibble(table = character(), col_tracker_zoom = list())
 }
 
 #' Validator
@@ -792,7 +792,7 @@ empty_dm <- function() {
       fks = vctrs::list_of(new_fk()),
       filters = vctrs::list_of(new_filter()),
       zoom = list(),
-      key_tracker_zoom = list()
+      col_tracker_zoom = list()
     )
   )
 }

--- a/R/dm.R
+++ b/R/dm.R
@@ -349,10 +349,18 @@ dm_get_def <- function(x) {
 dm_get_data_model_pks <- function(x) {
   # FIXME: Obliterate
 
-  pk_df <-
-    dm_get_def(x) %>%
+  dm_get_def(x) %>%
     select(table, pks) %>%
-    unnest(pks)
+    unnest_pks()
+}
+
+unnest_pks <- function(def) {
+  # Optimized
+  pk_df <- tibble(
+    table = rep(def$table, map_int(def$pks, nrow))
+  )
+
+  pk_df <- vctrs::vec_cbind(pk_df, vctrs::vec_rbind(!!!def$pks))
 
   # FIXME: Should work better with dplyr 0.9.0
   if (!("column" %in% names(pk_df))) {

--- a/R/global.R
+++ b/R/global.R
@@ -37,7 +37,7 @@ utils::globalVariables(c(
   "into",
   "is_key",
   "key",
-  "key_tracker_zoom",
+  "col_tracker_zoom",
   "kind",
   "mismatch_or_null",
   "name",

--- a/R/key-helpers.R
+++ b/R/key-helpers.R
@@ -237,9 +237,9 @@ check_fk_constraints <- function(dm) {
     select(table = t1_name, kind, column = colname, ref_table = t2_name, is_key, problem)
 }
 
-new_tracked_keys <- function(dm, selected) {
-  tracked_keys <- get_tracked_keys(dm)
-  old_tracked_names <- names(tracked_keys)
+new_tracked_cols <- function(dm, selected) {
+  tracked_cols <- get_tracked_cols(dm)
+  old_tracked_names <- names(tracked_cols)
   # the new tracked keys need to be the remaining original column names
   # and their name needs to be the newest one (tidyselect-syntax)
   # `intersect(selected, old_tracked_names)` is empty, return `NULL`
@@ -247,7 +247,7 @@ new_tracked_keys <- function(dm, selected) {
     NULL
   } else {
     set_names(
-      tracked_keys[selected[selected %in% old_tracked_names]],
+      tracked_cols[selected[selected %in% old_tracked_names]],
       names(selected[selected %in% old_tracked_names])
     )
   }

--- a/R/learn.R
+++ b/R/learn.R
@@ -216,7 +216,7 @@ legacy_new_dm <- function(tables, data_model) {
   # would be logical NA otherwise, but if set, it is class `character`
   display <- as.character(data_model_tables$display)
   zoom <- new_zoom()
-  key_tracker_zoom <- new_key_tracker_zoom()
+  col_tracker_zoom <- new_col_tracker_zoom()
 
   pks <-
     pks %>%
@@ -260,7 +260,7 @@ legacy_new_dm <- function(tables, data_model) {
     left_join(fks, by = "table") %>%
     left_join(filters, by = "table") %>%
     left_join(zoom, by = "table") %>%
-    left_join(key_tracker_zoom, by = "table")
+    left_join(col_tracker_zoom, by = "table")
 
   new_dm3(def)
 }

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -139,8 +139,13 @@ dm_get_pk <- function(dm, table) {
 }
 
 dm_get_pk_impl <- function(dm, table_name) {
-  pks <- dm_get_data_model_pks(dm)
-  pks$column[pks$table == table_name]
+  # Optimized
+  dm %>%
+    dm_get_def() %>%
+    select(table, pks) %>%
+    filter(table == !!table_name) %>%
+    unnest_pks() %>%
+    pull(column)
 }
 
 #' Get all primary keys of a [`dm`] object

--- a/R/select.R
+++ b/R/select.R
@@ -55,11 +55,3 @@ dm_select <- function(dm, table, ...) {
     select(...) %>%
     dm_update_zoomed()
 }
-
-get_all_keys <- function(dm, table_name) {
-  fks <- dm_get_all_fks_impl(dm) %>%
-    filter(child_table == table_name) %>%
-    pull(child_fk_cols)
-  pk <- dm_get_pk_impl(dm, table_name)
-  set_names(unique(c(pk, fks)))
-}

--- a/R/test-dm.R
+++ b/R/test-dm.R
@@ -99,17 +99,17 @@ check_one_zoom <- function(def, zoomed) {
     if (sum(!map_lgl(def$zoom, is_null)) < 1) {
       abort_dm_invalid("Class is `zoomed_dm` but no zoomed table available.")
     }
-    if (sum(!map_lgl(def$key_tracker_zoom, is_null)) > 1) {
+    if (sum(!map_lgl(def$col_tracker_zoom, is_null)) > 1) {
       abort_dm_invalid("Key tracking is active for more than one zoomed table.")
     }
-    if (sum(!map_lgl(def$key_tracker_zoom, is_null)) < 1) {
+    if (sum(!map_lgl(def$col_tracker_zoom, is_null)) < 1) {
       abort_dm_invalid("No key tracking is active despite `dm` a `zoomed_dm`.")
     }
   } else {
     if (sum(!map_lgl(def$zoom, is_null)) != 0) {
       abort_dm_invalid("Zoomed table(s) available despite `dm` not a `zoomed_dm`.")
     }
-    if (sum(!map_lgl(def$key_tracker_zoom, is_null)) != 0) {
+    if (sum(!map_lgl(def$col_tracker_zoom, is_null)) != 0) {
       abort_dm_invalid("Key tracker for zoomed table activated despite `dm` not a `zoomed_dm`.")
     }
   }

--- a/R/tidyr.R
+++ b/R/tidyr.R
@@ -39,9 +39,9 @@ unite.zoomed_dm <- function(data, col, ..., sep = "_", remove = TRUE, na.rm = FA
   united_tbl <- unite(tbl, col = !!col, ..., sep = sep, remove = remove, na.rm = na.rm)
   # all columns that are not not removed count as "selected"; names of "selected" are identical to "selected"
   if (remove) deselected <- tidyselect::vars_select(colnames(tbl), ...) else deselected <- character()
-  selected <- set_names(setdiff(names(get_tracked_keys(data)), deselected))
-  new_tracked_keys_zoom <- new_tracked_keys(data, selected)
-  replace_zoomed_tbl(data, united_tbl, new_tracked_keys_zoom)
+  selected <- set_names(setdiff(names(get_tracked_cols(data)), deselected))
+  new_tracked_cols_zoom <- new_tracked_cols(data, selected)
+  replace_zoomed_tbl(data, united_tbl, new_tracked_cols_zoom)
 }
 
 #' @export
@@ -57,7 +57,7 @@ separate.zoomed_dm <- function(data, col, into, sep = "[^[:alnum:]]+", remove = 
   separated_tbl <- separate(tbl, col = !!col, into = into, sep = sep, remove = remove, ...)
   # all columns that are not removed count as "selected"; names of "selected" are identical to "selected"
   deselected <- if (remove) col else character()
-  selected <- set_names(setdiff(names(get_tracked_keys(data)), deselected))
-  new_tracked_keys_zoom <- new_tracked_keys(data, selected)
-  replace_zoomed_tbl(data, separated_tbl, new_tracked_keys_zoom)
+  selected <- set_names(setdiff(names(get_tracked_cols(data)), deselected))
+  new_tracked_cols_zoom <- new_tracked_cols(data, selected)
+  replace_zoomed_tbl(data, separated_tbl, new_tracked_cols_zoom)
 }

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -309,15 +309,6 @@ check_not_zoomed <- function(dm) {
   abort_only_possible_wo_zoom(fun_name)
 }
 
-# FIXME: remove after #266?
-get_all_keys <- function(dm, table_name) {
-  fks <- dm_get_all_fks_impl(dm) %>%
-    filter(child_table == table_name) %>%
-    pull(child_fk_cols)
-  pk <- dm_get_pk_impl(dm, table_name)
-  set_names(unique(c(pk, fks)))
-}
-
 get_all_cols <- function(dm, table_name) {
   set_names(colnames(tbl(dm, table_name)))
 }

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -267,11 +267,12 @@ orig_name_zoomed <- function(dm) {
   dm_get_zoomed_tbl(dm) %>% pull(table)
 }
 
-replace_zoomed_tbl <- function(dm, new_zoomed_tbl, tracked_cols) {
+replace_zoomed_tbl <- function(dm, new_zoomed_tbl, tracked_cols = NULL) {
   table <- orig_name_zoomed(dm)
   def <- dm_get_def(dm)
   def$zoom[def$table == table] <- list(new_zoomed_tbl)
-  def$col_tracker_zoom[def$table == table] <- list(tracked_cols)
+  # the tracked columns are only replaced if they changed, otherwise this function is called with default `NULL`
+  if (!is_null(tracked_cols)) def$col_tracker_zoom[def$table == table] <- list(tracked_cols)
   new_dm3(def, zoomed = TRUE)
 }
 

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -298,6 +298,7 @@ check_not_zoomed <- function(dm) {
   abort_only_possible_wo_zoom(fun_name)
 }
 
+# FIXME: remove after #266?
 get_all_keys <- function(dm, table_name) {
   fks <- dm_get_all_fks_impl(dm) %>%
     filter(child_table == table_name) %>%

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -257,8 +257,7 @@ dm_update_zoomed_outgoing_fks <- function(dm, new_tbl_name, is_upd) {
   )
 }
 
-
-get_tracked_keys <- function(dm) {
+get_tracked_cols <- function(dm) {
   dm_get_def(dm) %>%
     filter(table == orig_name_zoomed(dm)) %>%
     pull(col_tracker_zoom) %>%

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -297,3 +297,11 @@ check_not_zoomed <- function(dm) {
   fun_name <- as_string(sys.call(-1)[[1]])
   abort_only_possible_wo_zoom(fun_name)
 }
+
+get_all_keys <- function(dm, table_name) {
+  fks <- dm_get_all_fks_impl(dm) %>%
+    filter(child_table == table_name) %>%
+    pull(child_fk_cols)
+  pk <- dm_get_pk_impl(dm, table_name)
+  set_names(unique(c(pk, fks)))
+}

--- a/R/zoom.R
+++ b/R/zoom.R
@@ -80,8 +80,7 @@ dm_zoom_to <- function(dm, table) {
   zoom <- as_string(ensym(table))
   check_correct_input(dm, zoom)
 
-  keys <- list(get_all_keys(dm, zoom))
-  cols <- get_all_cols(dm, zoom)
+  cols <- list(get_all_cols(dm, zoom))
 
   structure(
     new_dm3(
@@ -204,10 +203,10 @@ dm_discard_zoomed <- function(dm) {
 
 update_zoomed_pk <- function(dm) {
   old_tbl_name <- orig_name_zoomed(dm)
-  tracked_keys <- get_tracked_keys(dm)
+  tracked_cols <- get_tracked_cols(dm)
   orig_pk <- dm_get_pk_impl(dm, old_tbl_name)
-  upd_pk <- if (!is_empty(orig_pk) && orig_pk %in% tracked_keys) {
-    new_pk(list(names(tracked_keys[tracked_keys == orig_pk])))
+  upd_pk <- if (!is_empty(orig_pk) && orig_pk %in% tracked_cols) {
+    new_pk(list(names(tracked_cols[tracked_cols == orig_pk])))
   } else {
     new_pk()
   }
@@ -216,9 +215,9 @@ update_zoomed_pk <- function(dm) {
 
 update_zoomed_incoming_fks <- function(dm) {
   old_tbl_name <- orig_name_zoomed(dm)
-  tracked_keys <- get_tracked_keys(dm)
+  tracked_cols <- get_tracked_cols(dm)
   orig_pk <- dm_get_pk_impl(dm, old_tbl_name)
-  if (!is_empty(orig_pk) && orig_pk %in% tracked_keys) {
+  if (!is_empty(orig_pk) && orig_pk %in% tracked_cols) {
     filter(dm_get_def(dm), table == old_tbl_name) %>% pull(fks)
   } else {
     vctrs::list_of(new_fk())
@@ -229,15 +228,15 @@ update_zoomed_incoming_fks <- function(dm) {
 # if `is_upd`, new_tbl_name needs to be the same as old_tbl_name
 dm_update_zoomed_outgoing_fks <- function(dm, new_tbl_name, is_upd) {
   old_tbl_name <- orig_name_zoomed(dm)
-  tracked_keys <- get_tracked_keys(dm)
+  tracked_cols <- get_tracked_cols(dm)
   old_out_keys <- dm_get_all_fks_impl(dm) %>%
     filter(child_table == old_tbl_name) %>%
     select(table = parent_table, column = child_fk_cols)
 
   old_and_new_out_keys <-
-    if (nrow(old_out_keys) > 0 && any(old_out_keys$column %in% tracked_keys)) {
-      filter(old_out_keys, column %in% tracked_keys) %>%
-        mutate(new_column = names(tracked_keys[match(column, tracked_keys, nomatch = 0L)]))
+    if (nrow(old_out_keys) > 0 && any(old_out_keys$column %in% tracked_cols)) {
+      filter(old_out_keys, column %in% tracked_cols) %>%
+        mutate(new_column = names(tracked_cols[match(column, tracked_cols, nomatch = 0L)]))
     } else {
       filter(old_out_keys, 0 == 1) %>% mutate(new_column = character(0))
     }

--- a/tests/testthat/helper-zoom.R
+++ b/tests/testthat/helper-zoom.R
@@ -1,0 +1,9 @@
+
+# helper to check if key tracking works
+get_all_keys <- function(dm, table_name) {
+  fks <- dm_get_all_fks_impl(dm) %>%
+    filter(child_table == table_name) %>%
+    pull(child_fk_cols)
+  pk <- dm_get_pk_impl(dm, table_name)
+  set_names(unique(c(pk, fks)))
+}

--- a/tests/testthat/test-dm-dm.R
+++ b/tests/testthat/test-dm-dm.R
@@ -158,9 +158,9 @@ test_that("validator speaks up (sqlite)", {
 })
 
 test_that("validator speaks up when something's wrong", {
-  # key tracker of non-zoomed dm contains entries
+  # col tracker of non-zoomed dm contains entries
   expect_dm_error(
-    new_dm3(dm_get_def(dm_for_filter) %>% mutate(key_tracker_zoom = list(1))) %>% validate_dm(),
+    new_dm3(dm_get_def(dm_for_filter) %>% mutate(col_tracker_zoom = list(1))) %>% validate_dm(),
     "dm_invalid"
   )
 
@@ -170,9 +170,9 @@ test_that("validator speaks up when something's wrong", {
     "dm_invalid"
   )
 
-  # key tracker of zoomed dm is empty
+  # col tracker of zoomed dm is empty
   expect_dm_error(
-    new_dm3(dm_get_def(dm_for_filter %>% dm_zoom_to(t1)) %>% mutate(key_tracker_zoom = list(NULL)), zoomed = TRUE) %>% validate_dm(),
+    new_dm3(dm_get_def(dm_for_filter %>% dm_zoom_to(t1)) %>% mutate(col_tracker_zoom = list(NULL)), zoomed = TRUE) %>% validate_dm(),
     "dm_invalid"
   )
 

--- a/tests/testthat/test-dm-dplyr.R
+++ b/tests/testthat/test-dm-dplyr.R
@@ -604,9 +604,11 @@ test_that("key tracking works", {
       filter(child_fk_cols != "dim_4_key")
   )
 
-  expect_identical(slice(zoomed_dm, if_else(d < 5, 1:6, 7:2), .keep_pk = FALSE) %>% get_tracked_keys(), set_names(c("d", "e")))
-  expect_identical(slice(zoomed_dm, if_else(d < 5, 1:6, 7:2)) %>% get_tracked_keys(), set_names(c("c", "d", "e")))
-  expect_identical(slice(zoomed_dm, if_else(d < 5, 1:6, 7:2), .keep_pk = TRUE) %>% get_tracked_keys(), set_names(c("c", "d", "e")))
+  expect_identical(slice(zoomed_dm, if_else(d < 5, 1:6, 7:2), .keep_pk = FALSE) %>% get_tracked_cols(), set_names(c("d", "e")))
+  expect_message(
+    expect_identical(slice(zoomed_dm, if_else(d < 5, 1:6, 7:2)) %>% get_tracked_cols(), set_names(c("c", "d", "e"))),
+    "Keeping PK")
+  expect_identical(slice(zoomed_dm, if_else(d < 5, 1:6, 7:2), .keep_pk = TRUE) %>% get_tracked_cols(), set_names(c("c", "d", "e")))
 
   # it should be possible to combine 'filter' on a zoomed_dm with all other dplyr-methods; example: 'rename'
   expect_equivalent_dm(

--- a/tests/testthat/test-dm-zoom.R
+++ b/tests/testthat/test-dm-zoom.R
@@ -118,3 +118,11 @@ test_that("dm_update_tbl() works", {
       new_dm3()
   )
 })
+
+# after #271:
+test_that("all cols are tracked in zoomed table", {
+  expect_identical(
+    dm_zoom_to(dm_nycflights_small, flights) %>% get_tracked_cols(),
+    set_names(colnames(tbl(dm_nycflights_small, "flights")))
+  )
+})


### PR DESCRIPTION
should be quicker eventually:

- all columns are tracked of zoomed_table
- columns are removed from tracker under certain circumstances (mutate, deselect, etc.)
- if all columns are still tracked all keys will remain:
	This feature is only available for `dm_update_zoomed()`, since we need to access the key columns of the original table specifically when using `dm_insert_zoomed()` in order to replicate the keys for the new table

closes #266 