### PR TITLE
Use dplyr::tbl_sum() to get formatted database string

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -507,13 +507,17 @@ format.dm <- function(x, ...) {
 print.dm <- function(x, ...) {
   cat_rule("Table source", col = "green")
   def <- dm_get_def(x)
+  src <- dm_get_src(x)
+  db_info <- NULL
 
-  if (nrow(def) == 0) {
-    src <- dm_get_src(x)
+  if (!is.null(src$con) && nrow(def) >= 0) {
+    tbl_str <- dplyr::tbl_sum(def$data[[1]])
+    if ("Database" %in% names(tbl_str)) {
+      db_info <- paste0("src:  ", tbl_str[["Database"]])
+    }
+  }
+  if (is.null(db_info)) {
     db_info <- strsplit(format(src), "\n")[[1]][[1]]
-  } else {
-    db_str <- dplyr::tbl_sum(def$data[[1]])[["Database"]]
-    db_info <- paste("src:", db_str)
   }
 
   cat_line(db_info)

--- a/R/dm.R
+++ b/R/dm.R
@@ -506,15 +506,20 @@ format.dm <- function(x, ...) {
 #' @import cli
 print.dm <- function(x, ...) {
   cat_rule("Table source", col = "green")
-  src <- dm_get_src(x)
+  def <- dm_get_def(x)
 
-  db_info <- strsplit(format(src), "\n")[[1]][[1]]
+  if (nrow(def) == 0) {
+    src <- dm_get_src(x)
+    db_info <- strsplit(format(src), "\n")[[1]][[1]]
+  } else {
+    db_str <- dplyr::tbl_sum(def$data[[1]])[["Database"]]
+    db_info <- paste("src:", db_str)
+  }
 
   cat_line(db_info)
 
   cat_rule("Metadata", col = "violet")
 
-  def <- dm_get_def(x)
   cat_line("Tables: ", commas(tick(def$table)))
   cat_line("Columns: ", def_get_n_columns(def))
   cat_line("Primary keys: ", def_get_n_pks(def))

--- a/R/dm.R
+++ b/R/dm.R
@@ -511,7 +511,8 @@ print.dm <- function(x, ...) {
   db_info <- NULL
 
   if (!is.null(src$con) && nrow(def) >= 0) {
-    tbl_str <- dplyr::tbl_sum(def$data[[1]])
+    # FIXME: change to pillar::tbl_sum() once it's there
+    tbl_str <- tibble::tbl_sum(def$data[[1]])
     if ("Database" %in% names(tbl_str)) {
       db_info <- paste0("src:  ", tbl_str[["Database"]])
     }


### PR DESCRIPTION
(See #307 for background.)

While poking around to create a precise issue for dbplyr, I realized that `db_desc()` is also exposed via `dplyr::tbl_sum()` where it is called without the expensive `src_tbls()` call.

This PR modified `print.dm` to call `dplyr::tbl_sum()` on one table in the dm object and use the `"Database"` entry.
If no tables are included in the dm object, it falls back to the previous `dbplyr::format.src_sql()` approach.

With my test case, the timing went down, um, _considerably_. It turns out the previous approach took about 15 seconds on average. This new approach takes less than a 1/10 of a second.