### PR TITLE
Learn keys from SQLite databases

### DIFF
--- a/R/db-helpers.R
+++ b/R/db-helpers.R
@@ -163,6 +163,11 @@ is_postgres <- function(dest) {
     inherits(dest, "PqConnection")
 }
 
+is_sqlite <- function(dest) {
+  inherits(dest, "SQLiteConnection") ||
+    inherits(dest, "src_SQLiteConnection")
+}
+
 src_from_src_or_con <- function(dest) {
   if (is.src(dest)) dest else dbplyr::src_dbi(dest)
 }


### PR DESCRIPTION
Hi all, I know there are a few things currently in motion with respect to SQLite databases, so I'm submitting this with the complete expectation that you may want to implement this in another way. Please take whatever you find useful.

The primary change I've made is to add an `sqlite_learn_query()` that's wired up through `db_learn_query()` and that returns a table of table and column information in same structure as `postgres_learn_query()`.

I've added a small test to confirm that my changes work, and I know I'm not taking full advantage of your testing infrastructure. I tried to setup a test using `dm_nycflights_small()` but the foreign keys weren't making the round trip and I wasn't sure if this was a bug or a problem with how I was using `copy_dm_to()`. I'd be happy to revise the tests with a little guidance.