### PR TITLE
Revert "Avoid testing on R < 3.6 due to known rmarkdown bug"

### DIFF
--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -36,6 +36,12 @@ jobs:
           - { os: ubuntu-latest, r: "release", MODE: "db-tests", id: "db-tests" }
           # [Custom matrix env var]
           - { os: ubuntu-latest, r: 3.6, id: "default" }
+          # [Custom matrix env var]
+          - { os: ubuntu-latest, r: 3.5, id: "default" }
+          # [Custom matrix env var]
+          - { os: ubuntu-latest, r: 3.4, id: "default" }
+          # [Custom matrix env var]
+          - { os: ubuntu-latest, r: 3.3, id: "default" }
 
     env:
       # [Custom env var]


### PR DESCRIPTION
once rmarkdown > 2.2 is on CRAN.

This reverts commit 6757da59c2c7fac21b8d2cb27ec8943bbe1e8948.