### PR TITLE
GHA: Use a custom PAT to increase rate limit

### DIFF
--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -71,7 +71,7 @@ jobs:
       # macOS >= 10.15.4 linking
       SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
       # use GITHUB_TOKEN from GItHub to workaround rate limits in {remotes}
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.DM_PAT }}
 
     steps:
       - uses: actions/checkout@v2.1.1


### PR DESCRIPTION
As discussed in https://github.com/krlmlr/dm/issues/374#issuecomment-640413457.

Using a custom GitHub PAT (scopeless) as a secret instead of the default `GITHUB_TOKEN` secrets bumps the rate from 1000 to 5000: https://github.com/krlmlr/dm/runs/748994181?check_suite_focus=true#step:18:95

