### PR TITLE
GHA: Remove `ccache` parts from tic.yml

### DIFF
--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -70,7 +70,7 @@ jobs:
       TIC_BUILD_PKGDOWN: ${{ matrix.config.pkgdown }}
       # macOS >= 10.15.4 linking
       SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
-      # use GITHUB_TOKEN from GItHub to workaround rate limits in {remotes}
+      # use GITHUB_TOKEN from GitHub to workaround rate limits in {remotes}
       GITHUB_PAT: ${{ secrets.DM_PAT }}
 
     steps:
@@ -99,58 +99,24 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date '+%d-%m')"
 
-      - name: "[Cache] Prepare weekly timestamp for cache"
-        if: runner.os != 'Windows'
-        id: datew
-        run: echo "::set-output name=datew::$(date '+%Y-%V')"
-
       - name: "[Cache] Cache R packages"
         if: runner.os != 'Windows'
-        uses: pat-s/always-upload-cache@v1.2.0
+        uses: pat-s/always-upload-cache@v2.0.0
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ steps.date.outputs.date }}-${{ matrix.config.cache }}
           restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ steps.date.outputs.date }}-${{ matrix.config.cache }}
 
-      - name: "[Cache] Cache ccache"
-        if: runner.os != 'Windows'
-        uses: pat-s/always-upload-cache@v1.2.0
-        with:
-          path: ${{ env.CCACHE_DIR}}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
-
       # install ccache and write config file
       - name: "[Linux] ccache"
         if: runner.os == 'Linux'
         run: |
-          sudo apt install ccache libcurl4-openssl-dev
-          mkdir -p ~/.R && echo -e 'CC=ccache gcc -std=gnu99\nCXX=ccache g++\nFC=ccache gfortran\nF77=ccache gfortran' > $HOME/.R/Makevars
+          sudo apt install libcurl4-openssl-dev
 
       - name: "[Custom block] [Linux] Install libraries"
         if: runner.os == 'Linux'
         run: |
           sudo apt install libpq-dev libmysqlclient-dev libssh2-1-dev libsodium-dev libv8-dev
-
-      # install ccache and write config file
-      # mirror the setup described in https://github.com/rmacoslib/r-macos-rtools
-      - name: "[macOS] ccache"
-        if: runner.os == 'macOS' && matrix.config.r == 'devel'
-        run: |
-          brew install ccache
-          # install SDK 10.13 (High Sierra, used by CRAN)
-          wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz
-          tar fxz MacOSX10.13.sdk.tar.xz
-          sudo mv MacOSX10.13.sdk /Library/Developer/CommandLineTools/SDKs/
-          rm -rf MacOSX10.13*
-          # install gfortran 8.2 (used by CRAN)
-          wget -nv https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg
-          sudo hdiutil attach gfortran*.dmg
-          sudo installer -package /Volumes/gfortran*/gfortran*/gfortran*.pkg -target /
-          sudo hdiutil detach /Volumes/gfortran-8.2-Mojave
-          rm gfortran-8*
-          # set compiler flags
-          mkdir -p ~/.R && echo -e 'CC=ccache clang\nCPP=ccache clang\nCXX=ccache clang++\nCXX11=ccache clang++\nCXX14=ccache clang++\nCXX17=ccache clang++\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk -I/usr/local/include\nF77=ccache /usr/local/gfortran/bin/gfortran\nFC=ccache /usr/local/gfortran/bin/gfortran' > $HOME/.R/Makevars
 
       # for some strange Windows reason this step and the next one need to be decoupled
       - name: "[Stage] Prepare"


### PR DESCRIPTION
and update caching action version.

gfortran 8.2 (CRAN default) is meanwhile also installed upstream by r-lib/actions.