### PR TITLE
fix test

### DIFF
--- a/tests/testthat/test-db-interface.R
+++ b/tests/testthat/test-db-interface.R
@@ -90,6 +90,6 @@ test_that("table identifiers are quoted", {
     map_chr(dbplyr::remote_name)
 
   con <- dm_get_con(dm)
-  pattern <- unclass(DBI::dbQuoteIdentifier(con, "[a-z0-9_]+"))
+  pattern <- unclass(DBI::dbQuoteIdentifier(con, "[a-z0-9_#]+"))
   expect_true(all(grepl(pattern, remote_names)))
 })


### PR DESCRIPTION
It seems to me that due to the commit https://github.com/krlmlr/dm/pull/419/commits/60882491aff6342f152bb9a4915fe1f2e4477565 `#` is also part of the remote name and therefore the test would fail on MSSQL if we don't add it to the pattern.