### PR TITLE
Better error message for bad table_names, forbid local target in copy_dm_to

### DIFF
--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -107,8 +107,8 @@ jobs:
         uses: pat-s/always-upload-cache@v2.0.0
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ steps.date.outputs.date }}-${{ matrix.config.cache }}-${{ matrix.config.id }}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ steps.date.outputs.date }}-${{ matrix.config.cache }}-${{ matrix.config.id }}
+          key: ${{ runner.os }}-r1-${{ matrix.config.r }}-${{ steps.date.outputs.date }}-${{ matrix.config.cache }}-${{ matrix.config.id }}
+          restore-keys: ${{ runner.os }}-r1-${{ matrix.config.r }}-${{ steps.date.outputs.date }}-${{ matrix.config.cache }}-${{ matrix.config.id }}
 
       # install ccache and write config file
       - name: "[Linux] Prepare"

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -106,9 +106,9 @@ copy_dm_to <- function(dest, dm, ...,
     abort_no_unique_indexes()
   }
 
-  if (!is_null(unique_table_names)) {
+  if (!is.null(unique_table_names)) {
     lifecycle::deprecate_soft(
-      "0.1.4", "copy_dm_to(unique_table_names = )",
+      "0.1.4", "dm::copy_dm_to(unique_table_names = )",
       details = "Use `table_names = identity` to use unchanged names for temporary tables."
     )
 
@@ -153,7 +153,7 @@ copy_dm_to <- function(dest, dm, ...,
     # FIXME: Other data sources than local and database possible
     if (!is.null(table_names)) {
       lifecycle::deprecate_soft(
-        "0.1.6", "copy_dm_to(table_names = 'must be NULL if copying to a local source')"
+        "0.1.6", "dm::copy_dm_to(table_names = 'must be NULL if copying to a local source')"
       )
     }
     table_names_out <- set_names(src_names)

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -143,6 +143,11 @@ copy_dm_to <- function(dest, dm, ...,
       }
       check_naming(names(table_names_out), src_names)
 
+      if (anyDuplicated(table_names_out)) {
+        problem <- table_names_out[duplicated(table_names_out)][[1]]
+        abort_copy_dm_to_table_names_duplicated(problem)
+      }
+
       table_names_out <- unclass(DBI::dbQuoteIdentifier(dest_con, table_names_out[src_names]))
       # names(table_names_out) <- src_names
     }
@@ -248,10 +253,21 @@ check_naming <- function(table_names, dm_table_names) {
 
 # Errors ------------------------------------------------------------------
 
-abort_copy_dm_to_table_names <- function(problems) {
+abort_copy_dm_to_table_names <- function() {
   abort(error_txt_copy_dm_to_table_names(), .subclass = dm_error_full("copy_dm_to_table_names"))
 }
 
 error_txt_copy_dm_to_table_names <- function() {
   "`table_names` must have names that are the same as the table names in `dm`."
+}
+
+abort_copy_dm_to_table_names_duplicated <- function(problem) {
+  abort(error_txt_copy_dm_to_table_names_duplicated(problem), .subclass = dm_error_full("copy_dm_to_table_names_duplicated"))
+}
+
+error_txt_copy_dm_to_table_names_duplicated <- function(problem) {
+  c(
+    "`table_names` must be unique.",
+    i = paste0("Duplicate: ", tick(problem))
+  )
 }

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -156,11 +156,10 @@ copy_dm_to <- function(dest, dm, ...,
     table_names_out <- map(table_names_out, dbplyr::ident_q)
   } else {
     # FIXME: Other data sources than local and database possible
-    if (!is.null(table_names)) {
-      lifecycle::deprecate_soft(
-        "0.1.6", "dm::copy_dm_to(table_names = 'must be NULL if copying to a local source')"
-      )
-    }
+    lifecycle::deprecate_soft(
+      "0.1.6", "dm::copy_dm_to(dest = 'must refer to a remote data source')",
+      "dm::collect.dm()"
+    )
     table_names_out <- set_names(src_names)
   }
 

--- a/tests/testthat/test-db-interface.R
+++ b/tests/testthat/test-db-interface.R
@@ -18,7 +18,9 @@ test_that("copy_dm_to() copies data frames to databases", {
 
 test_that("copy_dm_to() copies data frames from any source", {
   expect_equivalent_dm(
-    copy_dm_to(default_local_src(), dm_for_filter()),
+    expect_deprecated(
+      copy_dm_to(default_local_src(), dm_for_filter())
+    ),
     dm_for_filter()
   )
 })
@@ -33,6 +35,7 @@ test_that("copy_dm_to() copies to SQLite", {
 })
 
 test_that("copy_dm_to() copies from SQLite", {
+  skip_if_local_src()
   skip_if_not_installed("RSQLite")
 
   expect_equivalent_dm(

--- a/tests/testthat/test-db-interface.R
+++ b/tests/testthat/test-db-interface.R
@@ -56,8 +56,11 @@ test_that("copy_dm_to() rejects overwrite and types arguments", {
   )
 })
 
-# set up for test: in order for the unique table names to return the same result each time, we need to trick the function
-test_repair_table_names_for_db <- function(table_names, temporary) {
+test_that("default table repair works", {
+  skip_if_local_src()
+
+  con <- con_from_src_or_con(my_test_src())
+
   orig_table_names <- c("t1", "t2", "t3")
 
   my_unique_db_table_name <- function(table_name) {
@@ -68,16 +71,16 @@ test_repair_table_names_for_db <- function(table_names, temporary) {
     unique_db_table_name = my_unique_db_table_name,
     {
       expect_equal(
-        repair_table_names_for_db(table_names, temporary = TRUE),
-        my_unique_db_table_name(table_names)
+        repair_table_names_for_db(table_names, temporary = TRUE, con),
+        quote_ids(my_unique_db_table_name(table_names), con)
       )
       expect_equal(
-        repair_table_names_for_db(table_names, temporary = FALSE),
-        table_names
+        repair_table_names_for_db(table_names, temporary = FALSE, con),
+        quote_ids(table_names, con)
       )
     }
   )
-}
+})
 
 test_that("table identifiers are quoted", {
   skip_if_local_src()

--- a/tests/testthat/test-db-interface.R
+++ b/tests/testthat/test-db-interface.R
@@ -56,6 +56,18 @@ test_that("copy_dm_to() rejects overwrite and types arguments", {
   )
 })
 
+test_that("copy_dm_to() fails with duplicate table names", {
+  skip_if_local_src()
+
+  bad_names <- set_names(names(dm_for_filter()))
+  bad_names[[2]] <- bad_names[[1]]
+
+  expect_dm_error(
+    copy_dm_to(my_test_src(), dm_for_filter(), table_names = bad_names),
+    class = "copy_dm_to_table_names_duplicated"
+  )
+})
+
 test_that("default table repair works", {
   skip_if_local_src()
 

--- a/tests/testthat/test-db-interface.R
+++ b/tests/testthat/test-db-interface.R
@@ -61,23 +61,22 @@ test_that("default table repair works", {
 
   con <- con_from_src_or_con(my_test_src())
 
-  orig_table_names <- c("t1", "t2", "t3")
+  table_names <- c("t1", "t2", "t3")
+
+  calls <- 0
 
   my_unique_db_table_name <- function(table_name) {
+    calls <<- calls + 1
     glue::glue("{table_name}_2020_05_15_10_45_29_0")
   }
 
   testthat::with_mock(
     unique_db_table_name = my_unique_db_table_name,
     {
-      expect_equal(
-        repair_table_names_for_db(table_names, temporary = TRUE, con),
-        quote_ids(my_unique_db_table_name(table_names), con)
-      )
-      expect_equal(
-        repair_table_names_for_db(table_names, temporary = FALSE, con),
-        quote_ids(table_names, con)
-      )
+      repair_table_names_for_db(table_names, temporary = FALSE, con)
+      expect_equal(calls, 0)
+      repair_table_names_for_db(table_names, temporary = TRUE, con)
+      expect_gt(calls, 0)
     }
   )
 })


### PR DESCRIPTION
in `copy_dm_to()`.

Closes #397.

Closes #395.