### PR TITLE
Add hint for export to svg to draw-vignette (Closes #481)

### DIFF
--- a/vignettes/tech-dm-draw.Rmd
+++ b/vignettes/tech-dm-draw.Rmd
@@ -85,7 +85,7 @@ flights_dm_w_many_keys_and_colors %>%
 
 Finally, for exporting a drawing to `svg` you could use `DiagrammeRsvg::export_svg()`:
 
-```{r}
+```{r eval = rlang::is_installed("DiagrammeRsvg")}
 flights_dm_w_many_keys_and_colors %>% 
   dm_select_tbl(flights, airports, planes) %>% 
   dm_draw() %>% 

--- a/vignettes/tech-dm-draw.Rmd
+++ b/vignettes/tech-dm-draw.Rmd
@@ -82,3 +82,13 @@ flights_dm_w_many_keys_and_colors %>%
   dm_select_tbl(flights, airports, planes) %>% 
   dm_draw()
 ```
+
+Finally, for exporting a drawing to `svg` you could use `DiagrammeRsvg::export_svg()`:
+
+```{r}
+flights_dm_w_many_keys_and_colors %>% 
+  dm_select_tbl(flights, airports, planes) %>% 
+  dm_draw() %>% 
+  DiagrammeRsvg::export_svg() %>% 
+  write("flights_dm_w_many_keys_and_color.svg")
+``` 


### PR DESCRIPTION
Following the discussion in issue `Add feature to write dm_draw #481` a good solution for export of a drawing could be `svg`.